### PR TITLE
Fix to mysql5-innodb plugin

### DIFF
--- a/plugins/dstat_mysql5_innodb.py
+++ b/plugins/dstat_mysql5_innodb.py
@@ -2,6 +2,8 @@
 
 global mysql_options
 mysql_options = os.getenv('DSTAT_MYSQL')
+if mysql_options is None:
+    mysql_options = ''
 
 global target_status
 global _basic_status


### PR DESCRIPTION
Prevents the mysql5_innodb plugin from giving mysql the
wrong arguments and thus hanging dstat or not giving output.

Running dstat with the plugin hangs.

``` bash
./dstat --mysql5-innodb
./dstat:1771: DeprecationWarning: os.popen3 is deprecated.  Use the subprocess module.
  pipes[cmd] = os.popen3(cmd, 't', 0)
^C
```

From pdb I found this:

```
python -m pdb dstat --mysql5-innodb
> /root/dstat/dstat(18)<module>()
-> from __future__ import generators
(Pdb) b plugins/dstat_mysql5_innodb.py:94
Breakpoint 1 at /root/dstat/plugins/dstat_mysql5_innodb.py:94
(Pdb) c
dstat:1771: DeprecationWarning: os.popen3 is deprecated.  Use the subprocess module.
  pipes[cmd] = os.popen3(cmd, 't', 0)
> /root/dstat/plugins/dstat_mysql5_innodb.py(94)extract()
-> self.stdin.write('show global status;\n')
(Pdb) p mysql_options
None
(Pdb) p self.stderr.read()
"ERROR 1049 (42000): Unknown database 'None'\n"
```
