### PR TITLE
Find plugins in installed location

### DIFF
--- a/plugins_path
+++ b/plugins_path
@@ -66,6 +66,7 @@ if sys.version_info < (2, 3):
 pluginpath = [
     os.path.expanduser('~/.dstat/'),                                # home + /.dstat/
     os.path.abspath(os.path.dirname(sys.argv[0])) + '/plugins/',    # binary path + /plugins/
+    os.path.abspath(os.path.dirname(sys.argv[0])) + '/../share/dstat/',    # binary path + /../share/dstat/
     '/usr/share/dstat/',
     '/usr/local/share/dstat/',
 ]


### PR DESCRIPTION
Currently, if dstat is installed by:

make install DESTDIR=...

then dstat cannot find the plugins. This commit fixes it by looking for the ../share/dstat directory relative to the installed binary.
