### PR TITLE
Fix TypeError: remove param in gettermcolor() call

### DIFF
--- a/dstat
+++ b/dstat
@@ -252,7 +252,7 @@ class Options:
         print
 
         color = ""
-        if not gettermcolor(self.color):
+        if not gettermcolor():
             color = "no "
         print 'Terminal type: %s (%scolor support)' % (os.getenv('TERM'), color)
         rows, cols = gettermsize()


### PR DESCRIPTION
gettermcolor() signature changed in 62b3b539
