### PR TITLE
Bugfix: No python2 in /usr/bin/env list

### DIFF
--- a/dstat
+++ b/dstat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 ### This program is free software; you can redistribute it and/or
 ### modify it under the terms of the GNU General Public License


### PR DESCRIPTION
In some OS where low version python installed, the soft link for python2 may be not existed.
