### PR TITLE
Increased width requirement of --tcp from 3 to 4.

### DIFF
--- a/dstat
+++ b/dstat
@@ -1497,7 +1497,7 @@ class dstat_tcp(dstat):
         self.nick = ('lis', 'act', 'syn', 'tim', 'clo')
         self.vars = ('listen', 'established', 'syn', 'wait', 'close')
         self.type = 'd'
-        self.width = 3
+        self.width = 4
         self.scale = 100
         self.open('/proc/net/tcp', '/proc/net/tcp6')
 


### PR DESCRIPTION
--tcp truncates the last 3 digits off a value (1000 becomes 1).
It is pretty common to have 4 digit 'established connections' these days, pushing the issue down the road by increasing width from 3 to 4.

TODO: Have some sort of overload, or add a scale (1000 becomes 1k)
