### PR TITLE
intuitive color-coding overhaul

### DIFF
--- a/dstat
+++ b/dstat
@@ -1996,10 +1996,27 @@ def cprintlist(varlist, type, width, scale, nick):
         i = i+1
     return ret
 
+global_maxima = {}
+
 def cprint(var, type = 'f', width = 4, scale = 1000, nick='?'):
     "Color print one column"
 
-    #print >>sys.stderr, 'args=', var, type, width, scale, nick
+    global global_maxima
+
+    try:
+        max = global_maxima[nick]
+    except KeyError:
+        # A hokey way to avoid divide-by-zero... never have a 0 maxima...
+        global_maxima[nick] = max = 1
+
+    if ( var > max ):
+        global_maxima[nick] = max = var
+
+    percent = round(100*var/max)
+    if (percent <   0): percent = 0
+    if (percent > 100): percent = 100
+
+    #print >>sys.stderr, 'args=', nick, type, var, max, percent
 
     base = 1000
     if scale == 1024:
@@ -2072,12 +2089,15 @@ def cprint(var, type = 'f', width = 4, scale = 1000, nick='?'):
     elif type in ('p'):
         color_index = int(round((len(colors)-1)*(100-var)/100))
         color = colors[color_index]
-    elif scale not in (1000, 1024):
-        color = colors[int(var/scale)%len(colors)]
-    elif type in ('b', 'd', 'f'):
-        color = colors[c%len(colors)]
     else:
-        color = ctext
+        color = colors[int(round((len(colors)-1)*(100-percent)/100))]
+
+    #elif scale not in (1000, 1024):
+    #    color = colors[int(var/scale)%len(colors)]
+    #elif type in ('b', 'd', 'f'):
+    #    color = colors[c%len(colors)]
+    #else:
+    #    color = ctext
 
     ### Justify value to left if string
     if type in ('s',):

--- a/dstat
+++ b/dstat
@@ -1635,23 +1635,25 @@ class dstat_zones(dstat):
 ### END STATS DEFINITIONS ###
 
 ansi = {
-    'black': '\033[0;30m',
-    'darkred': '\033[0;31m',
-    'darkgreen': '\033[0;32m',
-    'darkyellow': '\033[0;33m',
-    'darkblue': '\033[0;34m',
-    'darkmagenta': '\033[0;35m',
-    'darkcyan': '\033[0;36m',
-    'gray': '\033[0;37m',
+    'black'    : '\033[0;30m',
+    'darkgray' : '\033[1;30m',
+    'gray'     : '\033[0;37m',
+    'white'    : '\033[1;37m',
 
-    'darkgray': '\033[1;30m',
-    'red': '\033[1;31m',
-    'green': '\033[1;32m',
-    'yellow': '\033[1;33m',
-    'blue': '\033[1;34m',
+    'darkred'    : '\033[0;31m',
+    'darkyellow' : '\033[0;33m',
+    'darkgreen'  : '\033[0;32m',
+    'darkcyan'   : '\033[0;36m',
+    'darkblue'   : '\033[0;34m',
+    'darkmagenta': '\033[0;35m',
+
+    'red'    : '\033[1;31m',
+	'orange' : '\033[0;33m', # aka. darkyellow
+    'yellow' : '\033[1;33m',
+    'green'  : '\033[1;32m',
+    'cyan'   : '\033[1;36m',
+    'blue'   : '\033[1;34m',
     'magenta': '\033[1;35m',
-    'cyan': '\033[1;36m',
-    'white': '\033[1;37m',
 
     'blackbg': '\033[40m',
     'redbg': '\033[41m',
@@ -1714,10 +1716,9 @@ def set_theme():
             'text_hi': ansi['darkgray'],
             'unit_lo': ansi['black'],
             'unit_hi': ansi['darkgray'],
-            'colors_lo': (ansi['darkred'], ansi['darkmagenta'], ansi['darkgreen'], ansi['darkblue'],
-                          ansi['darkcyan'], ansi['black'], ansi['red'], ansi['green']),
-            'colors_hi': (ansi['red'], ansi['magenta'], ansi['green'], ansi['blue'],
-                          ansi['cyan'], ansi['darkgray'], ansi['darkred'], ansi['darkgreen']),
+            'colors': (ansi['red'], ansi['darkred'], ansi['darkyellow'], ansi['yellow'], ansi['cyan'], ansi['green'], ansi['darkgreen'], ansi['darkcyan'],
+                          ansi['darkblue'], ansi['blue'], ansi['black'], ansi['darkmagenta'], ansi['magenta'], ansi['darkgray'], ansi['gray'],
+                          ),
         }
     else:
         theme = {
@@ -1735,10 +1736,9 @@ def set_theme():
             'text_hi': ansi['darkgray'],
             'unit_lo': ansi['darkgray'],
             'unit_hi': ansi['darkgray'],
-            'colors_lo': (ansi['red'], ansi['yellow'], ansi['green'], ansi['blue'],
-                          ansi['cyan'], ansi['white'], ansi['darkred'], ansi['darkgreen']),
-            'colors_hi': (ansi['darkred'], ansi['darkyellow'], ansi['darkgreen'], ansi['darkblue'],
-                          ansi['darkcyan'], ansi['gray'], ansi['red'], ansi['green']),
+            'colors': (ansi['red'], ansi['darkred'], ansi['darkyellow'], ansi['yellow'], ansi['cyan'], ansi['green'], ansi['darkgreen'], ansi['darkcyan'],
+                          ansi['darkblue'], ansi['blue'], ansi['black'], ansi['darkmagenta'], ansi['magenta'], ansi['darkgray'], ansi['gray'],
+                          ),
         }
     return theme
 
@@ -2024,12 +2024,12 @@ def cprint(var, type = 'f', width = 4, scale = 1000):
         units = ('B', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
 
     if step == op.delay:
-        colors = theme['colors_lo']
+        colors = theme['colors']
         ctext = theme['text_lo']
         cunit = theme['unit_lo']
         cdone = theme['done_lo']
     else:
-        colors = theme['colors_hi']
+        colors = theme['colors']
         ctext = theme['text_hi']
         cunit = theme['unit_hi']
         cdone = theme['done_hi']

--- a/dstat
+++ b/dstat
@@ -2051,14 +2051,14 @@ def cprint(var, type = 'f', width = 4, scale = 1000):
         raise Exception, 'Type %s not known to dstat.' % type
 
     ### Set the counter color
-    if ret == '0':
-        color = cunit
-    elif scale <= 0:
-        color = ctext
+    if ret == '0' or scale <= 0:
+        color = colors[len(colors)-1]
     elif type in ('p') and round(var) >= 100.0:
-        color = cdone
-#    elif type in ('p'):
-#        color = colors[int(round(var)/scale)%len(colors)]
+        color = colors[0]
+    elif type in ('p'):
+        color_index = int(round((len(colors)-1)*(100-var)/100))
+        #print >>sys.stderr, color_index
+        color = colors[color_index]
     elif scale not in (1000, 1024):
         color = colors[int(var/scale)%len(colors)]
     elif type in ('b', 'd', 'f'):

--- a/dstat
+++ b/dstat
@@ -526,7 +526,7 @@ class dstat:
         "Display stat results"
         line = ''
         if hasattr(self, 'output'):
-            return cprint(self.output, self.type, self.width, self.scale)
+            return cprint(self.output, self.type, self.width, self.scale, self.nick)
         for i, name in enumerate(self.vars):
             if i < len(self.types):
                 type = self.types[i]
@@ -537,14 +537,14 @@ class dstat:
             else:
                 scale = self.scale
             if isinstance(self.val[name], types.TupleType) or isinstance(self.val[name], types.ListType):
-                line = line + cprintlist(self.val[name], type, self.width, scale)
+                line = line + cprintlist(self.val[name], type, self.width, scale, self.nick)
                 sep = theme['frame'] + char['colon']
                 if i + 1 != len(self.vars):
                     line = line + sep
             else:
                 ### Make sure we don't show more values than we have nicknames
                 if i >= len(self.nick): break
-                line = line + cprint(self.val[name], type, self.width, scale)
+                line = line + cprint(self.val[name], type, self.width, scale, self.nick[i])
                 sep = char['space']
                 if i + 1 != len(self.nick):
                     line = line + sep
@@ -1986,16 +1986,20 @@ def tchg(var, width):
                 ret = '%2dw' % (var / 60 / 24 / 7)
     return ret
 
-def cprintlist(varlist, type, width, scale):
+def cprintlist(varlist, type, width, scale, nick):
     "Return all columns color printed"
     ret = sep = ''
+    i=0
     for var in varlist:
-        ret = ret + sep + cprint(var, type, width, scale)
+        ret = ret + sep + cprint(var, type, width, scale, nick[i])
         sep = char['space']
+        i = i+1
     return ret
 
-def cprint(var, type = 'f', width = 4, scale = 1000):
+def cprint(var, type = 'f', width = 4, scale = 1000, nick='?'):
     "Color print one column"
+
+    #print >>sys.stderr, 'args=', var, type, width, scale, nick
 
     base = 1000
     if scale == 1024:
@@ -2050,14 +2054,23 @@ def cprint(var, type = 'f', width = 4, scale = 1000):
     else:
         raise Exception, 'Type %s not known to dstat.' % type
 
+    ### Not exactly intuitive, because lowest range is the same color; so 90 makes 87-100% idle the same color...
+    IDLE_SQUELNCH=90
+
     ### Set the counter color
-    if ret == '0' or scale <= 0:
+    if ( ret == '0' or scale <= 0 or round(var) <= 0 ) and nick in ('idl'):
+        color = colors[0]
+    elif ret == '0' or scale <= 0:
+        color = colors[len(colors)-1]
+    elif type in ('p') and round(var) >= IDLE_SQUELNCH and nick in ('idl'):
         color = colors[len(colors)-1]
     elif type in ('p') and round(var) >= 100.0:
-        color = colors[0]
+		color = colors[0]
+    elif type in ('p') and nick in ('idl'):
+        color_index = int(round((len(colors)-1)*(var)/IDLE_SQUELNCH))
+        color = colors[color_index]
     elif type in ('p'):
         color_index = int(round((len(colors)-1)*(100-var)/100))
-        #print >>sys.stderr, color_index
         color = colors[color_index]
     elif scale not in (1000, 1024):
         color = colors[int(var/scale)%len(colors)]


### PR DESCRIPTION
It's not expected that you accept this (I don't really know python, and this is my first hack on this codebase), but thought you might like to know the ideas:
- color spectrum semi-evenly ranges in frequency & brightness (red/orange/yellow/green/blue/violet)
- each variable dynamically senses it's maxima (so it takes some fluctuations to stabilize)
- all values color-coded by percentage (0 = gray/unnoticable, maximum/100% = bright red)
- "idle" column has the reverse logic (100% = gray/unnoticable, 0% = bright red)
