### PR TITLE
Fix the problem it cannot use 'all' and 'total' simultaneously about CPU

### DIFF
--- a/dstat
+++ b/dstat
@@ -625,6 +625,8 @@ class dstat_cpu(dstat):
                 varlist.append(str(cpu))
                 cpu = cpu + 1
 #           if len(varlist) > 2: varlist = varlist[0:2]
+            if 'total' in op.cpulist:
+                varlist.append('total')
         elif op.cpulist:
             varlist = op.cpulist
         else:


### PR DESCRIPTION
I want to show the CPU utilization of all cores and the average of them at the same time.
However, I cannot use 'all' and 'total' simultaneously like this.

``` bash
$ dstat -c -C all,total
-----cpu0-usage----------cpu1-usage----
usr sys idl wai stl:usr sys idl wai stl
  0   0 100   0   0:  0   0 100   0   0
```

I fix the problem it cannot use 'all' and 'total' simultaneously about CPU

``` bash
$ dstat -c -C all,total
-----cpu0-usage----------cpu1-usage-------total-cpu-usage--
usr sys idl wai stl:usr sys idl wai stl:usr sys idl wai stl
  0   0 100   0   0:  0   0 100   0   0:  0   0 100   0   0
```
