### PR TITLE
Fix incorrect number of columns about memory when outputting to a csv

### DIFF
--- a/dstat
+++ b/dstat
@@ -1286,17 +1286,21 @@ class dstat_mem(dstat):
     def __init__(self):
         self.name = 'memory usage'
         self.nick = ('used', 'free', 'buff', 'cach')
-        self.vars = ('MemTotal', 'MemUsed', 'MemFree', 'Buffers', 'Cached', 'Shmem', 'SReclaimable')
+        self.vars = ('MemUsed', 'MemFree', 'Buffers', 'Cached')
         self.open('/proc/meminfo')
 
     def extract(self):
+        adv_extract_vars = ('MemTotal', 'Shmem', 'SReclaimable')
+        adv_val={}
         for l in self.splitlines():
             if len(l) < 2: continue
             name = l[0].split(':')[0]
-            if name in self.vars + ('MemTotal', ):
+            if name in self.vars:
                 self.val[name] = long(l[1]) * 1024.0
+            elif name in adv_extract_vars:
+                adv_val[name] = long(l[1]) * 1024.0
 
-        self.val['MemUsed'] = self.val['MemTotal'] - self.val['MemFree'] - self.val['Buffers'] - self.val['Cached'] - self.val['SReclaimable'] + self.val['Shmem']
+        self.val['MemUsed'] = adv_val['MemTotal'] - self.val['MemFree'] - self.val['Buffers'] - self.val['Cached'] - adv_val['SReclaimable'] + adv_val['Shmem']
 
 class dstat_mem_adv(dstat_mem):
     """


### PR DESCRIPTION
With '-m' option, the number of columns seems wrong when outputting to a csv file.
'self.nick' and 'self.vars' are not symmetrical. 
This is for #73
```bash
$ dstat -m --output test.csv
------memory-usage-----
 used  free  buff  cach
3578M  243M  551M  166M
3578M  243M  551M  166M^C
$ cat test.csv
"Dstat 0.7.2svn CSV output"
"Author:","Dag Wieers <dag@wieers.com>",,,,"URL:","http://dag.wieers.com/home-made/dstat/"
"Host:","labkfub",,,,"User:","root"
"Cmdline:","dstat -m --output test.csv",,,,"Date:","11 Jun 2014 22:45:31 JST"
"memory usage",,,
"used","free","buff","cach"
3751710720,255250432,577626112,173756416,2630819840,2572288,116830208 #<- It seems wrong
3751710720,255221760,577650688,173756416,2630823936,2572288,116830208 #<- It seems wrong

$ dstat -mc --output test2.csv
------memory-usage----- --total-cpu-usage--
 used  free  buff  cach|usr sys idl wai stl
3578M  238M  556M  166M|  0   0 100   0   0
3578M  238M  556M  166M|  0   0 100   0   0^C
$ cat test2.csv
"Dstat 0.7.2svn CSV output"
"Author:","Dag Wieers <dag@wieers.com>",,,,"URL:","http://dag.wieers.com/home-made/dstat/"
"Host:","labkfub",,,,"User:","root"
"Cmdline:","dstat -mc --output test2.csv",,,,"Date:","11 Jun 2014 22:53:12 JST"
"memory usage",,,,"total cpu usage",,,,
"used","free","buff","cach","usr","sys","idl","wai","stl"
3751710720,249569280,583233536,173776896,2630905856,2592768,116817920,0.013,0.012,99.949,0.024,0.002 #<- It seems wrong seriously
3751710720,249532416,583266304,173776896,2630909952,2592768,116817920,0,0,100,0,0 #<- It seems wrong seriously
```
