### PR TITLE
Revert "Update plugins/dstat_mysql5_cmds.py"

### DIFF
--- a/plugins/dstat_mysql5_cmds.py
+++ b/plugins/dstat_mysql5_cmds.py
@@ -54,7 +54,9 @@ class dstat_plugin(dstat):
                 c.execute("""show global status like '%s';""" % name)
                 line = c.fetchone()
                 if line[0] in self.vars:
-                    self.set2[line[0]] = long(line[1])
+                    if line[0] + 'raw' in self.set2:
+                        self.set2[line[0]] = long(line[1]) - self.set2[line[0] + 'raw']
+                    self.set2[line[0] + 'raw'] = long(line[1])
 
             for name in self.vars:
                 self.val[name] = self.set2[name] * 1.0 / elapsed
@@ -65,5 +67,3 @@ class dstat_plugin(dstat):
         except Exception, e:
             for name in self.vars:
                 self.val[name] = -1
-
-# vim:ts=4:sw=4:et

--- a/plugins/dstat_mysql5_cmds.py
+++ b/plugins/dstat_mysql5_cmds.py
@@ -6,6 +6,15 @@ mysql_user = os.getenv('DSTAT_MYSQL_USER') or os.getenv('USER')
 global mysql_pwd
 mysql_pwd = os.getenv('DSTAT_MYSQL_PWD')
 
+global mysql_host
+mysql_host = os.getenv('DSTAT_MYSQL_HOST')
+
+global mysql_port
+mysql_port = os.getenv('DSTAT_MYSQL_PORT')
+
+global mysql_socket
+mysql_socket = os.getenv('DSTAT_MYSQL_SOCKET')
+
 class dstat_plugin(dstat):
     """
     Plugin for MySQL 5 commands.
@@ -22,7 +31,19 @@ class dstat_plugin(dstat):
         global MySQLdb
         import MySQLdb
         try:
-            self.db = MySQLdb.connect(user=mysql_user, passwd=mysql_pwd)
+            args = {}
+            if mysql_user:
+                args['user'] = mysql_user
+            if mysql_pwd:
+                args['passwd'] = mysql_pwd
+            if mysql_host:
+                args['host'] = mysql_host
+            if mysql_port:
+                args['port'] = mysql_port
+            if mysql_socket:
+                args['unix_socket'] = mysql_socket
+
+            self.db = MySQLdb.connect(**args)
         except Exception, e:
             raise Exception, 'Cannot interface with MySQL server: %s' % e
 
@@ -33,9 +54,7 @@ class dstat_plugin(dstat):
                 c.execute("""show global status like '%s';""" % name)
                 line = c.fetchone()
                 if line[0] in self.vars:
-                    if line[0] + 'raw' in self.set2:
-                        self.set2[line[0]] = long(line[1]) - self.set2[line[0] + 'raw']
-                    self.set2[line[0] + 'raw'] = long(line[1])
+                    self.set2[line[0]] = long(line[1])
 
             for name in self.vars:
                 self.val[name] = self.set2[name] * 1.0 / elapsed
@@ -46,3 +65,5 @@ class dstat_plugin(dstat):
         except Exception, e:
             for name in self.vars:
                 self.val[name] = -1
+
+# vim:ts=4:sw=4:et


### PR DESCRIPTION
This reverts commit fe5f91621f9c37671f359a75b40f4d6c29dd82e6.

I cannot understand why this file must take only two environment variables.
Other files about MySQL5 can take many environment variables.
Therefore, I guess that fe5f91621f9c37671f359a75b40f4d6c29dd82e6 is a mistake.