### PR TITLE
Bugfix for lustre plugin (python 2.7.3)

### DIFF
--- a/plugins/dstat_lustre.py
+++ b/plugins/dstat_lustre.py
@@ -17,15 +17,18 @@ class dstat_plugin(dstat):
 
     def extract(self):
         for name in self.vars:
-            for l in open(os.path.join('/proc/fs/lustre/llite', name, 'stats')).splitlines():
+            self.open(os.path.join('/proc/fs/lustre/llite', name, 'stats'))
+            for l in self.splitlines():
                 if len(l) < 6: continue
                 if l[0] == 'read_bytes':
                     read = long(l[6])
                 elif l[0] == 'write_bytes':
                     write = long(l[6])
             self.set2[name] = (read, write)
-
-            self.val[name] = map(lambda x, y: (y - x) * 1.0 / elapsed, self.set1[name], self.set2[name])
+            if hasattr(self.set1[name], "__getitem__"):
+                deltaRead = (self.set2[name][0] - self.set1[name][0]) * 1.0 / elapsed
+                deltaWrite = (self.set2[name][1] - self.set1[name][1]) * 1.0 / elapsed
+                self.val[name] = ( deltaRead, deltaWrite )
 
         if step == op.delay:
             self.set1.update(self.set2)


### PR DESCRIPTION
The lustre plugin wouldn't run for me in python 2.7.3 so I rewrote
some of the parsing code to update it for this version of python.
I'm not that familiar with differences in python over time, so I'm
not sure when the changes happened that caused this to fail to
compile. I also have not tested my fix against other versions of
python, but I'm happy to do so if you let me know which version(s)
are important to support. 
