### PR TITLE
Adding pymysql support to mysql5_innodb

### DIFF
--- a/plugins/dstat_mysql5_innodb.py
+++ b/plugins/dstat_mysql5_innodb.py
@@ -45,6 +45,7 @@ gauge = {
     'Threads_running'                 : 1,
     }
 
+
 class dstat_plugin(dstat):
     """
     mysql5-innodb, mysql5-innodb-basic, mysql5-innodb-extra
@@ -52,10 +53,96 @@ class dstat_plugin(dstat):
     display various metircs on MySQL5 and InnoDB.
     """
     def __init__(self):
+        class pymysqllib(object):
+            def __init__(self):
+                self.conn = None
+
+            def connect(self):
+                if op.debug:
+                    print 'mysql5_innodb using pymysql'
+                try:
+                    with open(os.path.expanduser("~/.my.cnf")) as dfile:
+                        try:
+                            import configparser
+                        except ImportError:
+                            import ConfigParser as configparser
+                        parser = configparser.ConfigParser()
+                        parser.readfp(dfile)
+			args = {}
+                        for k,v in parser.items('client'):
+                            args[k] = v
+                except IOError as e:
+                    import errno
+                    if e.errno != errno.ENOENT:
+                        raise e
+                    args = {}
+                self.conn = pymysql.connect(**args)
+
+            def reconnect(self):
+                self.conn = None
+                self.connect()
+
+            def execute(self, cmd):
+                cursor = self.conn.cursor()
+                cursor.execute(cmd)
+                while True:
+                    result = cursor.fetchone()
+                    if result is None:
+                        break
+                    yield result
+
+        class mysqlcmd(object):
+            def connect(self):
+                mysql_candidate = ('/usr/bin/mysql', '/usr/local/bin/mysql')
+                mysql_cmd = ''
+
+                for mc in mysql_candidate:
+                    if os.access(mc, os.X_OK):
+                        mysql_cmd = mc
+                        break
+
+                if mysql_cmd:
+                    if op.debug:
+                        print 'mysql5_innodb using %s' % mysql_cmd
+                    try:
+                        self.stdin, self.stdout, self.stderr = dpopen('%s -n %s' % (mysql_cmd, mysql_options))
+                    except IOError:
+                        raise Exception, 'Cannot interface with MySQL binary'
+                    return True
+                raise Exception, 'Needs MySQL binary'
+
+            def reconnect(self):
+                # XXX: This is never reached if mysql tries to exit.
+                #      That's because dpopen and readpipe aren't set
+                #      up to restart the program if it fails.
+                self.stdin.close()
+                self.stdout.close()
+                self.stderr.close()
+		self.connect()
+
+            def execute(self, cmd):
+                try:
+                    self.stdin.write('{};\n'.format(cmd))
+                    for line in readpipe(self.stdout):
+                        if line == '':
+                            break
+                        s = line.split()
+                        yield s
+                except IOError as e:
+                    if op.debug > 1:
+                        print '%s: lost pipe to mysql, %s' % (self.filename, e)
+                    raise
+
+
         self.name = 'MySQL5 InnoDB '
         self.type = 'd'
         self.width = 5
         self.scale = 1000
+        try:
+            import pymysql
+            self.mysqllib = pymysqllib()
+        except ImportError:
+            self.mysqllib = mysqlcmd()
 
     def check(self):
         if self.filename.find("basic") >= 0:
@@ -74,28 +161,12 @@ class dstat_plugin(dstat):
         self.vars = tuple( map((lambda e: e[0]), target_status) )
         self.nick = tuple( map((lambda e: e[1]), target_status) )
 
-        mysql_candidate = ('/usr/bin/mysql', '/usr/local/bin/mysql')
-        mysql_cmd = ''
-        for mc in mysql_candidate:
-            if os.access(mc, os.X_OK):
-                mysql_cmd = mc
-                break
+        self.mysqllib.connect()
 
-        if mysql_cmd:
-            try:
-                self.stdin, self.stdout, self.stderr = dpopen('%s -n %s' % (mysql_cmd, mysql_options))
-            except IOError:
-                raise Exception, 'Cannot interface with MySQL binary'
-            return True
-        raise Exception, 'Needs MySQL binary'
 
     def extract(self):
         try:
-            self.stdin.write('show global status;\n')
-            for line in readpipe(self.stdout):
-                if line == '':
-                    break
-                s = line.split()
+            for s in self.mysqllib.execute('show global status'):
                 if s[0] in self.vars:
                     self.set2[s[0]] = float(s[1])
                 elif s[0] in calculating_status:
@@ -112,11 +183,8 @@ class dstat_plugin(dstat):
             if step == op.delay:
                 self.set1.update(self.set2)
 
-        except IOError, e:
-            if op.debug > 1: print '%s: lost pipe to mysql, %s' % (self.filename, e)
-            for name in self.vars: self.val[name] = -1
-
         except Exception, e:
-            if op.debug > 1: print '%s: exception' % (self.filename, e)
+            if op.debug > 1: print '%s: exception %s' % (self.filename, e)
+            # try to reconnect
+            self.mysqllib.reconnect()
             for name in self.vars: self.val[name] = -1
-


### PR DESCRIPTION
Using the binary is susceptible to multiple problems that are not
really possible to work around without changes in dstat. Also using the
library will use less CPU and allows dstat to operate where the client
program is not installed.
