### PR TITLE
feat: jvm heap monitor

### DIFF
--- a/plugins/dstat_jvm_full.py
+++ b/plugins/dstat_jvm_full.py
@@ -10,7 +10,7 @@ class dstat_plugin(dstat):
     This plugin gathers jvm stats via jcmd.
 
     Usage:
-       dstat --jvm-full [ -I PID ]
+       JVM_PID=15123 dstat --jvm-full 
 
     Minimize the impacts of jcmd and consider using:
 
@@ -41,9 +41,10 @@ class dstat_plugin(dstat):
             raise Exception('Needs jstat binary')
 
         try:
-            int(op.intlist[0])
+            self.jvm_pid = int(os.environ.get('JVM_PID',0))
         except Exception as e:
-            op.intlist = [0]
+            self.jvm_pid = 0
+
         return True
 
     @staticmethod
@@ -63,7 +64,7 @@ class dstat_plugin(dstat):
     def extract(self):
         try:
             lines = self._cmd_splitlines(
-                '%s %s PerfCounter.print ' % (BIN_JCMD, op.intlist[0]))
+                '%s %s PerfCounter.print ' % (BIN_JCMD, self.jvm_pid))
             table = dict(self._to_stat(*l) for l in lines
                          if len(l) > 1)
             if table:

--- a/plugins/dstat_jvm_full.py
+++ b/plugins/dstat_jvm_full.py
@@ -1,0 +1,124 @@
+# Author: Roberto Polli <rpolli@redhat.com>
+#
+# NOTE: Edit the jcmd location according to your path or use update-alternatives.
+global BIN_JCMD
+BIN_JCMD = '/usr/bin/jcmd'
+
+
+class dstat_plugin(dstat):
+    """
+    This plugin gathers jvm stats via jcmd.
+
+    Usage:
+       dstat --jvm-full [ -I PID ]
+
+    Minimize the impacts of jcmd and consider using:
+
+        dstat --noupdate
+
+    For full informations on jcmd see:
+
+      - http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/jcmd.html
+      - https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr006.html
+
+    This requires the presence of /tmp/hsperfdata_* directory, so
+     it WON'T WORK if you add -XX:-UsePerfData or -XX:+PerfDisableSharedMem.
+
+    """
+
+    def __init__(self):
+        self.name = 'jvm_full'
+        self.vars = ('clsL', 'clsU', 'fgc', 'heap', 'heap%',
+                     'heapmax', 'perm', 'perm%', 'permmax')
+        self.type = 'f'
+        self.width = 5
+        self.scale = 1000
+
+    def check(self):
+        """Preliminar checks. If no pid is passed, defaults to 0.
+        """
+        if not os.access(BIN_JCMD, os.X_OK):
+            raise Exception('Needs jstat binary')
+
+        try:
+            int(op.intlist[0])
+        except Exception as e:
+            op.intlist = [0]
+        return True
+
+    @staticmethod
+    def _to_stat(k, v):
+        try:
+            return k, int(v)
+        except (KeyError, ValueError, AttributeError):
+            return k, v
+
+    @staticmethod
+    def _cmd_splitlines(cmd):
+        """Splits a txt output of lines like key=value.
+        """
+        for l in os.popen(cmd):
+            yield l.strip().split("=", 1)
+
+    def extract(self):
+        try:
+            lines = self._cmd_splitlines(
+                '%s %s PerfCounter.print ' % (BIN_JCMD, op.intlist[0]))
+            table = dict(self._to_stat(*l) for l in lines
+                         if len(l) > 1)
+            if table:
+                # Number of loaded classes.
+                self.set2['clsL'] = table['java.cls.loadedClasses']
+                self.set2['clsU'] = table['java.cls.unloadedClasses']
+                # Number of Full Garbage Collection events.
+                self.set2['fgc'] = table['sun.gc.collector.1.invocations']
+                # The heap space is made up of Old Generation and Young
+                # Generation (which is divided in Eden, Survivor0 and
+                # Survivor1)
+                self.set2['heap'] = table['sun.gc.generation.1.capacity'] + table[
+                    'sun.gc.generation.0.capacity']
+                # Usage is hidden in the nested spaces.
+                self.set2['heapu'] = sum(table[k] for k in table
+                                         if 'sun.gc.generation.' in k
+                                         and 'used' in k)
+                self.set2['heapmax'] = table['sun.gc.generation.1.maxCapacity'] + table[
+                    'sun.gc.generation.0.maxCapacity']
+
+                # Use PermGen on jdk7 and the new metaspace on jdk8
+                try:
+                    self.set2['perm'] = table['sun.gc.generation.2.capacity']
+                    self.set2['permu'] = sum(table[k] for k in table
+                                             if 'sun.gc.generation.2.' in k
+                                             and 'used' in k)
+                    self.set2['permmax'] = table[
+                        'sun.gc.generation.2.maxCapacity']
+                except KeyError:
+                    self.set2['perm'] = table['sun.gc.metaspace.capacity']
+                    self.set2['permu'] = table['sun.gc.metaspace.used']
+                    self.set2['permmax'] = table[
+                        'sun.gc.metaspace.maxCapacity']
+
+            # Evaluate statistics on memory usage.
+            for name in ('heap', 'perm'):
+                self.set2[name + '%'] = 100 * self.set2[
+                    name + 'u'] / self.set2[name]
+
+            for name in self.vars:
+                self.val[name] = self.set2[name]
+
+            if step == op.delay:
+                self.set1.update(self.set2)
+
+        except IOError, e:
+            if op.debug > 1:
+                print '%s: lost pipe to jstat, %s' % (self.filename, e)
+            for name in self.vars:
+                self.val[name] = -1
+
+        except Exception, e:
+            if op.debug > 1:
+                print '%s: exception' % e
+            for name in self.vars:
+                self.val[name] = -1
+
+# vim:ts=4:sw=4:et

--- a/plugins/dstat_jvm_vm.py
+++ b/plugins/dstat_jvm_vm.py
@@ -1,6 +1,6 @@
 # Author: Roberto Polli <rpolli@redhat.com>
 #
-# This plugin shows jvm stats using the -I argument.
+# This plugin shows jvm stats using the JVM_PID environment variable.
 # Requires the presence of the /tmp/hsperfdata_* directory and
 #  files created when running java with the profiler enabled.
 #
@@ -19,9 +19,10 @@ class dstat_plugin(dstat):
         if not os.access('/usr/bin/jstat', os.X_OK):
             raise Exception('Needs jstat binary')
         try:
-            int(op.intlist[0])
+            self.jvm_pid = int(os.environ.get('JVM_PID', 0))
         except Exception:
-            op.intlist = [0]
+            self.jvm_pid = 0
+
         return True
 
     @staticmethod
@@ -37,7 +38,7 @@ class dstat_plugin(dstat):
         from collections import namedtuple
         try:
             lines = self._cmd_splitlines(
-                '/usr/bin/jstat -gc %s' % op.intlist[0])
+                '/usr/bin/jstat -gc %s' % self.jvm_pid)
             headers = next(lines)
             DStatParser = namedtuple('DStatParser', headers)
             line = next(lines)

--- a/plugins/dstat_jvm_vm.py
+++ b/plugins/dstat_jvm_vm.py
@@ -1,0 +1,86 @@
+# Author: Roberto Polli <rpolli@redhat.com>
+#
+# This plugin shows jvm stats using the -I argument.
+# Requires the presence of the /tmp/hsperfdata_* directory and
+#  files created when running java with the profiler enabled.
+#
+
+
+class dstat_plugin(dstat):
+
+    def __init__(self):
+        self.name = 'jvm mem ops '
+        self.vars = ('fgc', 'heap', 'heap%', 'perm', 'perm%')
+        self.type = 'f'
+        self.width = 5
+        self.scale = 1000
+
+    def check(self):
+        if not os.access('/usr/bin/jstat', os.X_OK):
+            raise Exception('Needs jstat binary')
+        try:
+            int(op.intlist[0])
+        except Exception:
+            op.intlist = [0]
+        return True
+
+    @staticmethod
+    def _to_float(s):
+        return float(s.replace(",", "."))
+
+    @staticmethod
+    def _cmd_splitlines(cmd):
+        for l in os.popen(cmd):
+            yield l.strip().split()
+
+    def extract(self):
+        from collections import namedtuple
+        try:
+            lines = self._cmd_splitlines(
+                '/usr/bin/jstat -gc %s' % op.intlist[0])
+            headers = next(lines)
+            DStatParser = namedtuple('DStatParser', headers)
+            line = next(lines)
+            if line:
+                stats = DStatParser(*[self._to_float(x) for x in line])
+                # print stats
+                self.set2['cls'] = 0
+                self.set2['fgc'] = int(stats.FGC)
+                self.set2['heap'] = (
+                    stats.S0C + stats.S1C + stats.EC + stats.OC)
+                self.set2['heapu'] = (
+                    stats.S0U + stats.S1U + stats.EU + stats.OU)
+
+                # Use MetaSpace on jdk8
+                try:
+                    self.set2['perm'] = stats.PC
+                    self.set2['permu'] = stats.PU
+                except AttributeError:
+                    self.set2['perm'] = stats.MC
+                    self.set2['permu'] = stats.MU
+
+            # Evaluate statistics on memory usage.
+            for name in ('heap', 'perm'):
+                self.set2[name + '%'] = 100 * self.set2[
+                    name + 'u'] / self.set2[name]
+                self.set2[name] /= 1024
+
+            for name in self.vars:
+                self.val[name] = self.set2[name]
+
+            if step == op.delay:
+                self.set1.update(self.set2)
+
+        except IOError, e:
+            if op.debug > 1:
+                print '%s: lost pipe to jstat, %s' % (self.filename, e)
+            for name in self.vars:
+                self.val[name] = -1
+
+        except Exception, e:
+            if op.debug > 1:
+                print '%s: exception' % e
+            for name in self.vars:
+                self.val[name] = -1
+
+# vim:ts=4:sw=4:et


### PR DESCRIPTION
This plugins monitor jvm heap and classes usage.

Simple jstat counters: heap and perm/meta space:

```
# dstat --jvm-stat -I JVM_PID 5;
```

With jcmd counters, extensible version with some overhead: 

```
# dstat  --noupdate --jvm-full -I $JVM_PID 5;
```

Feedback welcome.
