### PR TITLE
Added MongoDB plugins

### DIFF
--- a/plugins/dstat_mongodb_conn.py
+++ b/plugins/dstat_mongodb_conn.py
@@ -1,0 +1,48 @@
+### Author: <gianfranco@mongodb.com>
+
+global mongodb_user
+mongodb_user = os.getenv('DSTAT_MONGODB_USER') or os.getenv('USER')
+
+global mongodb_pwd
+mongodb_pwd = os.getenv('DSTAT_MONGODB_PWD')
+
+global mongodb_host
+mongodb_host = os.getenv('DSTAT_MONGODB_HOST') or '127.0.0.1:27017'
+
+class dstat_plugin(dstat):
+  """
+  Plugin for MongoDB.
+  """
+  def __init__(self):
+    global pymongo
+    import pymongo
+
+    try:
+      self.m = pymongo.MongoClient(mongodb_host)
+      if mongodb_pwd:
+        self.m.admin.authenticate(mongodb_user, mongodb_pwd)
+      self.db = self.m.admin
+    except Exception, e:
+      raise Exception, 'Cannot interface with MongoDB server: %s' % e
+
+    self.name    = 'mongodb con'
+    self.nick    = ('curr', 'avail')
+    self.vars    = ('connections.current', 'connections.available')
+    self.type    = 'd'
+    self.width   = 5
+    self.scale   = 2
+    self.lastVal = {}
+
+  def extract(self):
+    status = self.db.command("serverStatus")
+
+    for name in self.vars:
+      self.val[name] = (long(self.getDoc(status, name)))
+
+  def getDoc(self, dic, doc):
+    par = doc.split('.')
+    sdic = dic
+    for p in par:
+      sdic = sdic.get(p)
+
+    return sdic

--- a/plugins/dstat_mongodb_mem.py
+++ b/plugins/dstat_mongodb_mem.py
@@ -1,0 +1,67 @@
+### Author: <gianfranco@mongodb.com>
+
+global mongodb_user
+mongodb_user = os.getenv('DSTAT_MONGODB_USER') or os.getenv('USER')
+
+global mongodb_pwd
+mongodb_pwd = os.getenv('DSTAT_MONGODB_PWD')
+
+global mongodb_host
+mongodb_host = os.getenv('DSTAT_MONGODB_HOST') or '127.0.0.1:27017'
+
+class dstat_plugin(dstat):
+  """
+  Plugin for MongoDB.
+  """
+  def __init__(self):
+    global pymongo
+    import pymongo
+
+    try:
+      self.m = pymongo.MongoClient(mongodb_host)
+      if mongodb_pwd:
+        self.m.admin.authenticate(mongodb_user, mongodb_pwd)
+      self.db = self.m.admin
+    except Exception, e:
+      raise Exception, 'Cannot interface with MongoDB server: %s' % e
+
+    line = self.db.command("serverStatus")
+    if 'storageEngine' in line:
+      self.storageEngine = line.get('storageEngine').get('name')
+    else:
+      self.storageEngine = 'mmapv1'
+
+    self.name    = 'mongodb mem'
+    self.nick    = ('res', 'virt')
+    self.vars    = ('mem.resident', 'mem.virtual')
+    self.type    = 'd'
+    self.width   = 5
+    self.scale   = 2
+    self.lastVal = {}
+
+    if self.storageEngine == 'mmapv1':
+      self.nick = self.nick + ('map', 'mapj', 'flt')
+      self.vars = self.vars + ('mem.mapped', 'mem.mappedWithJournal', 'extra_info.page_faults')
+
+
+  def extract(self):
+    status = self.db.command("serverStatus")
+
+    for name in self.vars:
+      if name in ('extra_info.page_faults'):
+        if not name in self.lastVal:
+          self.lastVal[name] = long(self.getDoc(status, name))
+        self.val[name] = (long(self.getDoc(status, name)) - self.lastVal[name])
+        self.lastVal[name] = self.getDoc(status, name)
+      else:
+        self.val[name] = (long(self.getDoc(status, name)))
+
+
+
+  def getDoc(self, dic, doc):
+    par = doc.split('.')
+    sdic = dic
+    for p in par:
+      sdic = sdic.get(p)
+
+    return sdic

--- a/plugins/dstat_mongodb_opcount.py
+++ b/plugins/dstat_mongodb_opcount.py
@@ -1,0 +1,46 @@
+### Author: <gianfranco@mongodb.com>
+
+global mongodb_user
+mongodb_user = os.getenv('DSTAT_MONGODB_USER') or os.getenv('USER')
+
+global mongodb_pwd
+mongodb_pwd = os.getenv('DSTAT_MONGODB_PWD')
+
+global mongodb_host
+mongodb_host = os.getenv('DSTAT_MONGODB_HOST') or '127.0.0.1:27017'
+
+class dstat_plugin(dstat):
+  """
+  Plugin for MongoDB.
+  """
+  def __init__(self):
+    global pymongo
+    import pymongo
+
+    try:
+      self.m = pymongo.MongoClient(mongodb_host)
+      if mongodb_pwd:
+        self.m.admin.authenticate(mongodb_user, mongodb_pwd)
+      self.db = self.m.admin
+    except Exception, e:
+      raise Exception, 'Cannot interface with MongoDB server: %s' % e
+
+    self.name    = 'mongodb counts'
+    self.nick    = ('qry', 'ins', 'upd', 'del', 'gtm', 'cmd')
+    self.vars    = ('query', 'insert','update','delete','getmore','command')
+    self.type    = 'd'
+    self.width   = 5
+    self.scale   = 2
+    self.lastVal = {}
+
+  def extract(self):
+    status = self.db.command("serverStatus")
+    opct = status['opcounters']
+
+    for name in self.vars:
+      if name in opct.iterkeys():
+        if not name in self.lastVal:
+          self.lastVal[name] = opct.get(name)
+
+        self.val[name]     = (long(opct.get(name)) - self.lastVal[name]) / elapsed
+        self.lastVal[name] = opct.get(name)

--- a/plugins/dstat_mongodb_queue.py
+++ b/plugins/dstat_mongodb_queue.py
@@ -1,0 +1,45 @@
+### Author: <gianfranco@mongodb.com>
+
+global mongodb_user
+mongodb_user = os.getenv('DSTAT_MONGODB_USER') or os.getenv('USER')
+
+global mongodb_pwd
+mongodb_pwd = os.getenv('DSTAT_MONGODB_PWD')
+
+global mongodb_host
+mongodb_host = os.getenv('DSTAT_MONGODB_HOST') or '127.0.0.1:27017'
+
+class dstat_plugin(dstat):
+  """
+  Plugin for MongoDB.
+  """
+  def __init__(self):
+    global pymongo
+    import pymongo
+
+    try:
+      self.m = pymongo.MongoClient(mongodb_host)
+      if mongodb_pwd:
+        self.m.admin.authenticate(mongodb_user, mongodb_pwd)
+      self.db = self.m.admin
+    except Exception, e:
+      raise Exception, 'Cannot interface with MongoDB server: %s' % e
+
+    self.name    = 'mongodb queues'
+    self.nick    = ('ar', 'aw', 'qt', 'qw')
+    self.vars    = ('ar', 'aw', 'qt', 'qw')
+    self.type    = 'd'
+    self.width   = 5
+    self.scale   = 2
+    self.lastVal = {}
+
+  def extract(self):
+    status = self.db.command("serverStatus")
+    glock = status['globalLock']
+    alock = glock['activeClients']
+    qlock = glock['currentQueue']
+
+    self.val['ar'] = long(alock['readers'])
+    self.val['aw'] = long(alock['writers'])
+    self.val['qr'] = long(qlock['readers'])
+    self.val['qw'] = long(qlock['writers'])

--- a/plugins/dstat_mongodb_stats.py
+++ b/plugins/dstat_mongodb_stats.py
@@ -1,0 +1,71 @@
+### Author: <gianfranco@mongodb.com>
+
+global mongodb_user
+mongodb_user = os.getenv('DSTAT_MONGODB_USER') or os.getenv('USER')
+
+global mongodb_pwd
+mongodb_pwd = os.getenv('DSTAT_MONGODB_PWD')
+
+global mongodb_host
+mongodb_host = os.getenv('DSTAT_MONGODB_HOST') or '127.0.0.1:27017'
+
+class dstat_plugin(dstat):
+  """
+  Plugin for MongoDB.
+  """
+  def __init__(self):
+    global pymongo
+    import pymongo
+
+    try:
+      self.m = pymongo.MongoClient(mongodb_host)
+      if mongodb_pwd:
+        self.m.admin.authenticate(mongodb_user, mongodb_pwd)
+      self.db = self.m.admin
+    except Exception, e:
+      raise Exception, 'Cannot interface with MongoDB server: %s' % e
+
+    stats  = self.db.command("listDatabases")
+    self.dbList = []
+    for db in stats.get('databases'):
+      self.dbList.append(db.get('name'))
+
+    line = self.db.command("serverStatus")
+    if 'storageEngine' in line:
+      self.storageEngine = line.get('storageEngine').get('name')
+    else:
+      self.storageEngine = 'mmapv1'
+
+    self.name    = 'mongodb stats'
+    self.nick    = ('dsize', 'isize', 'ssize')
+    self.vars    = ('dataSize', 'indexSize', 'storageSize')
+    self.type    = 'b'
+    self.width   = 5
+    self.scale   = 2
+    self.count   = 1
+
+    if self.storageEngine == 'mmapv1':
+      self.nick  = self.nick + ('fsize',)
+      self.vars  = self.vars + ('fileSize',)
+
+
+  def extract(self):
+    self.set = {}
+
+    # refresh the database list every 10 iterations
+    if (self.count % 10) == 0:
+      stats  = self.m.admin.command("listDatabases")
+      self.dbList = []
+      for db in stats.get('databases'):
+        self.dbList.append(db.get('name'))
+    self.count += 1
+
+    for name in self.vars:
+      self.set[name] = 0
+
+    for db in self.dbList:
+      self.db = self.m.get_database(db)
+      stats = self.db.command("dbStats")
+      for name in self.vars:
+        self.set[name] += long(stats.get(name)) / (1024 * 1024)
+    self.val = self.set


### PR DESCRIPTION
These plugins monitor MongoDB instances.
I added a global entry '--mongodb' to active all relevant plugins.
```
# dstat --mongodb
```

Host & authentication can be changed with the following env variables: DSTAT_MONGODB_USER, DSTAT_MONGODB_PWD and DSTAT_MONGODB_HOST. 

If you have any feedback, they are more than welcome :) (for more information, check my local [README](https://github.com/Dabz/dstat/blob/master/README.md) )