### PR TITLE
Fix broken mem-adv option

### DIFF
--- a/dstat
+++ b/dstat
@@ -1325,7 +1325,7 @@ class dstat_mem(dstat):
             name = l[0].split(':')[0]
             if name in self.vars:
                 self.val[name] = long(l[1]) * 1024.0
-            elif name in adv_extract_vars:
+            if name in adv_extract_vars:
                 adv_val[name] = long(l[1]) * 1024.0
 
         self.val['MemUsed'] = adv_val['MemTotal'] - self.val['MemFree'] - self.val['Buffers'] - self.val['Cached'] - adv_val['SReclaimable'] + adv_val['Shmem']


### PR DESCRIPTION
I'm sorry to cause you trouble.
My pull request(#76) breaks mem-adv option because --mem-adv option has 'MemTotal' in self.vars and adv_val['MemTotal'] is always undefined.

```bash
$ dstat --mem-adv
Traceback (most recent call last):
  File "./dstat", line 2812, in <module>
    main()
  File "./dstat", line 2673, in main
    scheduler.run()
  File "/usr/lib/python2.7/sched.py", line 117, in run
    action(*argument)
  File "./dstat", line 2767, in perform
    o.extract()
  File "./dstat", line 1303, in extract
    self.val['MemUsed'] = adv_val['MemTotal'] - self.val['MemFree'] - self.val['Buffers'] - self.val['Cached'] - adv_val['SReclaimable'] + adv_val['Shmem']
KeyError: 'MemTotal'
```