### PR TITLE
Clarify plugin option syntax

### DIFF
--- a/docs/dstat.1.adoc
+++ b/docs/dstat.1.adoc
@@ -142,7 +142,7 @@ information.
 --zones::
     enable zoneinfo stats (d32F, d32H, normF, normH)
 
---plugin-name::
+--<plugin-name>::
     enable (external) plugins by plugin name, see *PLUGINS* for options
 
 Possible internal stats are::

--- a/docs/dstat.1.html
+++ b/docs/dstat.1.html
@@ -1053,7 +1053,7 @@ information.</td>
 </p>
 </dd>
 <dt class="hdlist1">
---plugin-name
+--&lt;plugin-name&gt;
 </dt>
 <dd>
 <p>

--- a/dstat
+++ b/dstat
@@ -307,7 +307,7 @@ Dstat options:
   --zones                  enable zoneinfo stats
 
   --list                   list all available plugins
-  --plugin                 enable external plugin by name (see --list)
+  --<plugin-name>          enable external plugin by name (see --list)
 
   -a, --all                equals -cdngy (default)
   -f, --full               automatically expand -C, -D, -I, -N and -S lists


### PR DESCRIPTION
So... it took me a few seconds more than I would have liked to figure out what `--plugin` actually meant. Here's a simple (the description is much longer than the cure) attempt at fixing that:
##### ISSUE TYPE
- Docs pull-request
##### SUMMARY

The `--plugin-name` option syntax listed in the documentation could easily be mistaken for a literal `--plugin=<plugin-name>`-style option, when in fact the intended meaning is `--<plugin-name>`; with `<plugin-name>` being a place-holder.

Clarify matters by using this syntax in the documentation, and consistently using the same name in the output of `dstat -h`.
