### PR TITLE
lustre plugin error fix & add nfs4 client

### DIFF
--- a/dstat
+++ b/dstat
@@ -66,7 +66,7 @@ if sys.version_info < (2, 3):
 
 pluginpath = [
     os.path.expanduser('~/.dstat/'),                                # home + /.dstat/
-    os.path.abspath(os.path.dirname(sys.argv[0])) + '/plugins/',    # binary path + /plugins/
+    os.path.dirname(os.path.realpath(sys.argv[0])) + '/plugins/',    # binary path + /plugins/
     '/usr/share/dstat/',
     '/usr/local/share/dstat/',
 ]

--- a/plugins/dstat_lustre.py
+++ b/plugins/dstat_lustre.py
@@ -18,6 +18,8 @@ class dstat_plugin(dstat):
 
     def extract(self):
         for name in self.vars:
+            read = 0
+            write = 0
             for line in dopen(os.path.join('/proc/fs/lustre/llite', name, 'stats')).readlines():
                 l = line.split()
                 if len(l) < 6: continue

--- a/plugins/dstat_nfs4.py
+++ b/plugins/dstat_nfs4.py
@@ -1,0 +1,28 @@
+### Author: Dag Wieers <dag@wieers.com>
+
+class dstat_plugin(dstat):
+    def __init__(self):
+        self.name = 'nfs4 client'
+        self.nick = ('read', 'writ', 'rdir', 'othr', 'cmmt')
+        self.vars = ('read', 'write', 'readdir', 'other', 'commit')
+        self.type = 'd'
+        self.width = 5
+        self.scale = 1000
+        self.open('/proc/net/rpc/nfs')
+
+    def extract(self):
+        for l in self.splitlines():
+            if not l or l[0] != 'proc4': continue
+            self.set2['read'] = long(l[3])
+            self.set2['write'] = long(l[4])
+            self.set2['readdir'] = long(l[31])
+            self.set2['commit'] = long(l[5])
+            self.set2['other'] = sum(map(long, l[1:])) - self.set2['read'] - self.set2['write'] - self.set2['readdir'] - self.set2['commit']
+
+        for name in self.vars:
+            self.val[name] = (self.set2[name] - self.set1[name]) * 1.0 / elapsed
+
+        if step == op.delay:
+            self.set1.update(self.set2)
+
+# vim:ts=4:sw=4:et


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix pull-request
 - New Feature : nfs4_client plugins
 
##### DSTAT VERSION
```
<!--- Paste verbatim output from “dstat --version” here -->
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

Assigned read and write to zero prior to looking to actual values.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
The fix is for lustre filesystems with missing stats for read or write bytes

Feature: NFS4 client support