### PR TITLE
Added strongSwan plugin

### DIFF
--- a/plugins/dstat_strongswan.py
+++ b/plugins/dstat_strongswan.py
@@ -1,0 +1,64 @@
+### Author: Wang Jian <larkwang@gmail.com>
+
+import re
+
+global subprocess
+import subprocess
+
+class dstat_plugin(dstat):
+    """
+    Display ipsec tunnel traffic statistic. Especially useful for ipsec hub.
+    Written for strongSwan.
+    """
+    def __init__(self):
+
+        self.name = 'ipsec (bps)'
+
+        self.vars = []
+        lines = subprocess.check_output(["ipsec", "statusall"]).splitlines()
+        for l in lines:
+            m = re.search(" *(.*):.*rekeying", l)
+            if m:
+                name = m.group(1)
+                self.vars.append(name)
+
+        self.type = 's'
+        self.width = 11
+        self.scale = 0
+
+        self.counter1 = {}
+        self.counter2 = {}
+        self.re = re.compile(" *(.*):.* (.*) bytes_i.*, (.*) bytes_o")
+
+    def extract(self):
+        for name in self.vars:
+            if not self.counter2.has_key(name):
+                self.counter2[name] = { 'rx': 0, 'tx': 0 }
+            if not self.counter1.has_key(name):
+                self.counter1[name] = { 'rx': 0, 'tx': 0 }
+
+        self.output = ''
+
+        lines = subprocess.check_output(["ipsec", "statusall"]).splitlines()
+        for l in lines:
+            m = self.re.search(l)
+            if m:
+                name = m.group(1)
+                rx = long(m.group(2))
+                tx = long(m.group(3))
+                # after rekey, new ESP tunnel is created. new ESP tunnel is ignored
+                # to see new tunnel statistics, you need to restart dstat
+                if name in self.vars:
+                    self.counter2[name] = { 'rx': rx, 'tx': tx }
+
+        for name in self.vars:
+            rx_rate = (self.counter2[name]['rx'] - self.counter1[name]['rx']) * 8.0 / elapsed
+            tx_rate = (self.counter2[name]['tx'] - self.counter1[name]['tx']) * 8.0 / elapsed
+
+            self.output += "%s %s " % (cprint(rx_rate, type = 'd', width = 5, scale = 1000),
+                                       cprint(tx_rate, type = 'd', width = 5, scale = 1000))
+
+        if step == op.delay:
+            self.counter1.update(self.counter2)
+
+# vim:ts=4:sw=4:et


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New plugin pull-request

##### DSTAT VERSION
```
Dstat 0.7.3
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
Added strongSwan plugin, which parses `ipsec statusall` output and gathers traffic counters.

```
------------------------------ipsec-(bps)------------------------------
xxxxxx-idc{ yyyyyyyy-id zzzzzz-idc{ sssss-idc{8 ttttttttt-i uuuuuuuu-id
 471   140     0     0     0     0     0     0     0     0   167   612
 552k 2485k    0  4264     0     0     0     0   145k   79k 2330k  463k
3923k 1074k 1024  8528     0     0     0     0   220k 2573k  838k 1335k
2165k 1085k    0     0     0     0     0     0   291k  144k  776k 2015k
 556k 2618k 1024  8528     0     0     0     0   772k  122k 1815k  387k
 447k 1967k  512  4264     0     0     0     0   227k   90k 1717k  341k
 699k 2840k  512  4264     0     0     0     0   762k  178k 2019k  425k
6082k 7380k  512  4264     0     0     0     0  4550k 1565k 2816k 4504k

```
