### PR TITLE
dstat.1{,.{adoc,html}}: fix typo & make more consistent in verbiage

### DIFF
--- a/docs/dstat.1
+++ b/docs/dstat.1
@@ -29,7 +29,7 @@ Dstat is a versatile replacement for vmstat, iostat and ifstat\&. Dstat overcome
 .sp
 Dstat allows you to view all of your system resources instantly, you can eg\&. compare disk usage in combination with interrupts from your IDE controller, or compare the network bandwidth numbers directly with the disk throughput (in the same interval)\&.
 .sp
-Dstat also cleverly gives you the most detailed information in columns and clearly indicates in what magnitude and unit the output is displayed\&. Less confusion, less mistakes, more efficient\&.
+Dstat also cleverly gives you the most detailed information in columns and clearly indicates in what magnitude and unit the output is displayed\&. Less confusion, fewer mistakes, more efficiency\&.
 .sp
 Dstat is unique in letting you aggregate block device throughput for a certain diskset or network bandwidth for a group of interfaces, ie\&. you can see the throughput for all the block devices that make up a single filesystem or storage system\&.
 .sp

--- a/docs/dstat.1.adoc
+++ b/docs/dstat.1.adoc
@@ -22,7 +22,7 @@ the disk throughput (in the same interval).
 
 Dstat also cleverly gives you the most detailed information in columns
 and clearly indicates in what magnitude and unit the output is displayed.
-Less confusion, less mistakes, more efficient.
+Less confusion, fewer mistakes, more efficiency.
 
 Dstat is unique in letting you aggregate block device throughput for a
 certain diskset or network bandwidth for a group of interfaces, ie. 

--- a/docs/dstat.1.html
+++ b/docs/dstat.1.html
@@ -761,7 +761,7 @@ IDE controller, or compare the network bandwidth numbers directly with
 the disk throughput (in the same interval).</p></div>
 <div class="paragraph"><p>Dstat also cleverly gives you the most detailed information in columns
 and clearly indicates in what magnitude and unit the output is displayed.
-Less confusion, less mistakes, more efficient.</p></div>
+Less confusion, fewer mistakes, more efficiency.</p></div>
 <div class="paragraph"><p>Dstat is unique in letting you aggregate block device throughput for a
 certain diskset or network bandwidth for a group of interfaces, ie.
 you can see the throughput for all the block devices that make up a


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs pull-request

##### DSTAT VERSION
```
On top of commit 77e9347cf16a2cb08c7b79b40255b4700be81609 (Avoid escape characters when --nocolor)
```

##### SUMMARY
This change fixes a typo in the manpage et al. and makes the wording more uniform.