### PR TITLE
Add "team" to totalfilter in dstat_net_packets.py

### DIFF
--- a/plugins/dstat_net_packets.py
+++ b/plugins/dstat_net_packets.py
@@ -10,7 +10,7 @@ class dstat_plugin(dstat):
         self.type = 'd'
         self.width = 5
         self.scale = 1000
-        self.totalfilter = re.compile('^(lo|bond\d+|face|.+\.\d+)$')
+        self.totalfilter = re.compile('^(lo|bond|team\d+|face|.+\.\d+)$')
         self.open('/proc/net/dev')
         self.cols = 2
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
Dstat 0.7.2
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 3.10.0-327.el7.x86_64
Python 2.7.5 (default, Nov 20 2015, 02:00:19) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

Terminal type: linux (color support)
Terminal size: 67 lines, 232 columns

Processors: 32
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio, cpu, cpu24, disk, disk24, disk24old, epoch, fs, int, int24, io, ipc, load, lock, mem, net, page, page24, proc, raw, socket, swap, swapold, sys, tcp, time, udp, unix, vm
/usr/share/dstat:
        battery, battery-remain, cpufreq, dbus, disk-tps, disk-util, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, gpfs, gpfs-ops, helloworld, innodb-buffer, innodb-io, innodb-ops, lustre, memcache-hits, mysql-io, 
        mysql-keys, mysql5-cmds, mysql5-conn, mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops, nfsd3, nfsd3-ops, ntp, postfix, power, proc-count, qmail, rpc, rpcd, sendmail, snooze, squid, test, thermal, top-bio, top-bio-adv, 
        top-childwait, top-cpu, top-cpu-adv, top-cputime, top-cputime-avg, top-int, top-io, top-io-adv, top-latency, top-latency-avg, top-mem, top-oom, utmp, vm-memctl, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi
```

##### SUMMARY
In RHEL7, Network Teaming has been chosen to refer to a new implementation of "bonding", and as far as I know, we prefer using teaming instead of bonding in our new environment.

When using dstat to monitor network streaming, we found that dstat can't handle "team" card. For example, we use eth0 & eth1 for teaming, running net tests, the results which dstat return would be 118MB/s in --net/eht0--, 112MB/s in --net/team0--, and 230MB/s in --net/total--.

Here is my output.
```
[user@hostname ~]$ dstat -n -N lo,bond1,eth1,eth2,eth3,eth0,team0,total  
---net/lo----net/bond1----net/eth1----net/eth2----net/eth3----net/eth0---net/team0---net/total-
 recv  send: recv  send: recv  send: recv  send: recv  send: recv  send: recv  send: recv  send
   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 192B  138B:  52B  998B: 500B 1136B
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 262B 1124B:  52B 8950B: 570B   10k
   0     0 : 256B  128B:   0     0 : 128B  128B: 128B    0 :  70B 9218B:  52B  454B: 378B 9800B
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 :  70B  458B:  63M  177k:  63M  178k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 :  21M   63k: 112M  344k: 134M  407k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  365k: 112M  314k: 230M  678k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  312k: 230M  645k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  332k: 112M  314k: 230M  646k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  314k: 230M  647k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  334k: 112M  314k: 230M  648k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  334k: 112M  314k: 230M  648k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  334k: 112M  314k: 230M  648k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  334k: 112M  314k: 230M  648k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  334k: 112M  314k: 230M  648k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  334k: 112M  314k: 230M  648k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  334k: 112M  313k: 230M  647k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  391k: 230M  723k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  412k: 112M  313k: 230M  725k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  313k: 230M  646k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  313k: 230M  646k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  313k: 230M  646k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  313k: 230M  646k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k: 112M  313k: 230M  646k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 : 118M  333k:  50M  141k: 168M  474k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 :  93M  262k:  52B  454B:  93M  263k
   0     0 : 256B    0 :   0     0 : 128B    0 : 128B    0 :  70B  458B:  52B  454B: 378B  912B^C
```

Signed-off-by: Li Hongjie lihongjie@cmss.chinamobile.com