### PR TITLE
Added dstat_nvidia_gpu plugin which reports gpu usage.

### DIFF
--- a/plugins/dstat_nvidia_gpu.py
+++ b/plugins/dstat_nvidia_gpu.py
@@ -1,0 +1,41 @@
+### Author: Vasilis Vryniotis <bbriniotis@datumbox.com>
+
+class dstat_plugin(dstat):
+    """
+    Total GPU usage for NVIDIA cards. Requires the nvidia-ml-py package.
+
+    Usage: dstat --nvidia-gpu
+    """
+
+    def __init__(self):
+        self.name = 'gpu nvidia'
+        self.nick = ('gpu',)
+        self.vars = ('gpu',)
+        self.type = 'p'
+        self.width = 5
+        self.scale = 1
+
+    def check(self):
+        import pynvml
+        pynvml.nvmlInit()
+
+    def extract(self):
+        self.val['gpu'] = self._getTotalUsage(10)
+
+    def _getUsagePerGPU(self, samples):
+        import pynvml
+        usage = {}
+        deviceCount = pynvml.nvmlDeviceGetCount()
+        for iter in range(0, samples):
+            for i in range(0, deviceCount):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                if i not in usage:
+                    usage[i] = 0.0
+                usage[i] += pynvml.nvmlDeviceGetUtilizationRates(handle).gpu / float(samples)
+        return usage
+
+    def _getTotalUsage(self, samples):
+        usage = self._getUsagePerGPU(samples)
+        return sum(usage.values()) / len(usage)
+
+

--- a/plugins/dstat_nvidia_gpu.py
+++ b/plugins/dstat_nvidia_gpu.py
@@ -24,13 +24,11 @@ class dstat_plugin(dstat):
 
     def vars(self):
         ret = ['total']
-        """
-        #Uncomment to get statistics fo individual gpus.
-        import pynvml
-        deviceCount = pynvml.nvmlDeviceGetCount()
-        for i in range(0, deviceCount):
-            ret.append('gpu%d' % i)
-        """
+        if op.full:
+            import pynvml
+            deviceCount = pynvml.nvmlDeviceGetCount()
+            for i in range(0, deviceCount):
+                ret.append('gpu%d' % i)
         return ret
 
     def extract(self):

--- a/plugins/dstat_nvidia_gpu.py
+++ b/plugins/dstat_nvidia_gpu.py
@@ -8,19 +8,36 @@ class dstat_plugin(dstat):
     """
 
     def __init__(self):
-        self.name = 'gpu nvidia'
-        self.nick = ('gpu',)
-        self.vars = ('gpu',)
+        self.name = 'gpu usage nvidia'
         self.type = 'p'
         self.width = 5
-        self.scale = 1
+        self.scale = 34
+        self.cols = 1
+        self.samples = 10
 
     def check(self):
+        try:
+            import pynvml
+            pynvml.nvmlInit()
+        except:
+            raise Exception('The "pynvml" library is missing from this system.')
+
+    def vars(self):
+        ret = ['total']
+        """
+        #Uncomment to get statistics fo individual gpus.
         import pynvml
-        pynvml.nvmlInit()
+        deviceCount = pynvml.nvmlDeviceGetCount()
+        for i in range(0, deviceCount):
+            ret.append('gpu%d' % i)
+        """
+        return ret
 
     def extract(self):
-        self.val['gpu'] = self._getTotalUsage(10)
+        stats = self._getUsagePerGPU(self.samples)
+        stats['total'] = self._getTotalUsage(stats)
+        for name in self.vars:
+            self.val[name] = stats[name]
 
     def _getUsagePerGPU(self, samples):
         import pynvml
@@ -28,14 +45,14 @@ class dstat_plugin(dstat):
         deviceCount = pynvml.nvmlDeviceGetCount()
         for iter in range(0, samples):
             for i in range(0, deviceCount):
+                name = 'gpu%d' % i
                 handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-                if i not in usage:
-                    usage[i] = 0.0
-                usage[i] += pynvml.nvmlDeviceGetUtilizationRates(handle).gpu / float(samples)
+                if name not in usage:
+                    usage[name] = 0.0
+                usage[name] += pynvml.nvmlDeviceGetUtilizationRates(handle).gpu / float(samples)
         return usage
 
-    def _getTotalUsage(self, samples):
-        usage = self._getUsagePerGPU(samples)
-        return sum(usage.values()) / len(usage)
+    def _getTotalUsage(self, usage_per_gpu):
+        return sum(usage_per_gpu.values()) / len(usage_per_gpu)
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - New plugin pull-request

##### DSTAT VERSION
```
Dstat 0.7.2
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 4.4.0-62-generic
Python 2.7.12 (default, Nov 19 2016, 06:48:10) 
[GCC 5.4.0 20160609]

Terminal type: xterm (color support)
Terminal size: 24 lines, 96 columns

Processors: 64
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio, cpu, cpu24, disk, disk24, disk24old, epoch, fs, int, int24, io, ipc, load, lock, 
	mem, net, page, page24, proc, raw, socket, swap, swapold, sys, tcp, time, udp, unix, 
	vm
/usr/share/dstat:
	battery, battery-remain, cpufreq, dbus, disk-tps, disk-util, dstat, dstat-cpu, 
	dstat-ctxt, dstat-mem, fan, freespace, gpfs, gpfs-ops, helloworld, innodb-buffer, 
	innodb-io, innodb-ops, lustre, memcache-hits, mysql-io, mysql-keys, mysql5-cmds, 
	mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops, nfsd3, nfsd3-ops, ntp, 
	nvidia-gpu, postfix, power, proc-count, qmail, rpc, rpcd, sendmail, snooze, squid, 
	test, thermal, top-bio, top-bio-adv, top-childwait, top-cpu, top-cpu-adv, top-cputime, 
	top-cputime-avg, top-int, top-io, top-io-adv, top-latency, top-latency-avg, top-mem, 
	top-oom, utmp, vm-memctl, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi
```

##### SUMMARY
Created a new plugin that reports the GPU usage for nvidia cards. This would be useful for those that do GPU programming. The plugin requires the [nvidia-ml-py](https://pypi.python.org/pypi/nvidia-ml-py) package to collect data from the graphics cards.
