### PR TITLE
outputfile: reopen on signal.SIGUSR1

### DIFF
--- a/docs/dstat.1
+++ b/docs/dstat.1
@@ -298,7 +298,7 @@ disable intermediate updates when delay > 1
 .PP
 \-\-output file
 .RS 4
-write CSV output to file
+write CSV output to file\&. SIGUSR1 will reopen output file at some point before start of the next line\&.
 .RE
 .PP
 \-\-profile

--- a/docs/dstat.1.adoc
+++ b/docs/dstat.1.adoc
@@ -184,7 +184,8 @@ Possible internal stats are::
     disable intermediate updates when delay > 1
 
 --output file::
-    write CSV output to file
+    write CSV output to file. SIGUSR1 will reopen output file at some
+    point before start of the next line.
 
 --profile::
     show profiling statistics when exiting dstat

--- a/docs/dstat.1.html
+++ b/docs/dstat.1.html
@@ -1163,7 +1163,8 @@ Possible internal stats are
 </dt>
 <dd>
 <p>
-    write CSV output to file
+    write CSV output to file. SIGUSR1 will reopen output file at some
+    point before start of the next line.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -2072,7 +2073,7 @@ DSTAT_SNMPCOMMUNITY</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.7.3<br />
-Last updated 2015-07-04 14:07:27 CEST
+Last updated 2017-03-01 14:32:01 CST
 </div>
 </div>
 </body>

--- a/dstat
+++ b/dstat
@@ -19,7 +19,7 @@
 from __future__ import generators
 
 try:
-    import sys, os, time, sched, re, getopt, fnmatch
+    import sys, os, signal, time, sched, re, getopt, fnmatch
     import types, resource, getpass, glob, linecache
 except KeyboardInterrupt:
     pass
@@ -2533,10 +2533,25 @@ def exit(ret):
 
     sys.exit(ret)
 
+def reopen_outputfile_sig(signalnum, currstackframe):
+    "Sets the reopen_outputfile flag on external signal"
+    global reopen_outputfile
+    reopen_outputfile = True
+
+def reopen_outputfile_check():
+    "Called before line prints to reopen the output file, if signaled"
+    global outputfile, reopen_outputfile
+    if not reopen_outputfile:
+        return
+    reopen_outputfile = False
+    outputfile.close()
+    outputfile = open(op.output, 'a', 0)
+
 def main():
     "Initialization of the program, terminal, internal structures"
     global cpunr, hz, maxint, ownpid, pagesize
-    global ansi, theme, outputfile
+    global ansi, theme
+    global outputfile, reopen_outputfile
     global totlist, inittime
     global update, missed
 
@@ -2588,6 +2603,9 @@ def main():
         outputfile.write(char['sep'].join(header))
         header = ('"Cmdline:"','"dstat %s"' % ' '.join(op.args),'','','','"Date:"','"%s"\n' % time.strftime('%d %b %Y %H:%M:%S %Z', time.localtime()))
         outputfile.write(char['sep'].join(header))
+
+        reopen_outputfile = False
+        signal.signal(signal.SIGUSR1, reopen_outputfile_sig)
 
     ### Create pidfile
     if op.pidfile:
@@ -2807,6 +2825,7 @@ def perform(update):
         ### Print stats
         sys.stdout.write(line + theme['input'])
         if op.output and step == op.delay:
+            reopen_outputfile_check()
             outputfile.write(oline + '\n')
 #            outputfile.flush()
 

--- a/examples/dstat-daemon-logrotate.conf
+++ b/examples/dstat-daemon-logrotate.conf
@@ -1,0 +1,18 @@
+# Sample logrotate configuration file
+#
+# How to use?
+# Copy this file to /etc/logrotate.d/ and launch dstat via your
+# preferred system manager with the following command:
+#  dstat --output /var/log/dstat-daemon.csv --pidfile /var/run/dstat-daemon.pid
+# Ensure logrotate is installed and running as well.
+# This policy will rotate dstat-daemon.csv to dstat-daemon.csv.1, .2,
+# .3, .4, ..., .14, every day and prune older data.
+/var/log/dstat-daemon.csv {
+    daily
+    rotate 14
+    missingok
+    postrotate
+        kill -SIGUSR1 "`cat /var/run/dstat-daemon.pid`"
+    endscript
+    nocompress
+}


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature pull-request

##### DSTAT VERSION
```
Dstat 0.7.3
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 4.8.4-1-ARCH
Python 2.7.12 (default, Jun 28 2016, 08:31:05)
[GCC 6.1.1 20160602]

Terminal type: screen (color support)
Terminal size: 39 lines, 238 columns

Processors: 8
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio, cpu, cpu-adv, cpu-use, cpu24, disk, disk24, disk24-old, epoch, fs, int, int24, io, ipc, load, lock, mem, mem-adv, net, page, page24, proc, raw, socket, swap, swap-old, sys, tcp, time, udp, unix, vm, vm-adv, zones
/mnt/hd/data/home/hokanovi/Workspace/git/dstat/plugins:
        battery, battery-remain, condor-queue, cpufreq, dbus, disk-avgqu, disk-avgrq, disk-svctm, disk-tps, disk-util, disk-wait, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, fuse, gpfs, gpfs-ops, helloworld, ib,
        innodb-buffer, innodb-io, innodb-ops, jvm-full, jvm-vm, lustre, md-status, memcache-hits, mongodb-conn, mongodb-mem, mongodb-opcount, mongodb-queue, mongodb-stats, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-innodb,
        mysql5-innodb-basic, mysql5-innodb-extra, mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops, nfsd3, nfsd3-ops, nfsd4-ops, nfsstat4, ntp, postfix, power, proc-count, qmail, redis, rpc, rpcd, sendmail, snmp-cpu, snmp-load,
        snmp-mem, snmp-net, snmp-net-err, snmp-sys, snooze, squid, test, thermal, top-bio, top-bio-adv, top-childwait, top-cpu, top-cpu-adv, top-cputime, top-cputime-avg, top-int, top-io, top-io-adv, top-latency, top-latency-avg,
        top-mem, top-oom, utmp, vm-cpu, vm-mem, vm-mem-adv, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi, zfs-arc, zfs-l2arc, zfs-zil
/usr/share/dstat:
        battery, battery-remain, condor-queue, cpufreq, dbus, disk-avgqu, disk-avgrq, disk-svctm, disk-tps, disk-util, disk-wait, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, fuse, gpfs, gpfs-ops, helloworld, innodb-buffer,
        innodb-io, innodb-ops, lustre, md-status, memcache-hits, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-innodb, mysql5-innodb-basic, mysql5-innodb-extra, mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops, nfsd3,
        nfsd3-ops, nfsd4-ops, nfsstat4, ntp, postfix, power, proc-count, qmail, redis, rpc, rpcd, sendmail, snmp-cpu, snmp-load, snmp-mem, snmp-net, snmp-net-err, snmp-sys, snooze, squid, test, thermal, top-bio, top-bio-adv,
        top-childwait, top-cpu, top-cpu-adv, top-cputime, top-cputime-avg, top-int, top-io, top-io-adv, top-latency, top-latency-avg, top-mem, top-oom, utmp, vm-cpu, vm-mem, vm-mem-adv, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc,
        wifi, zfs-arc, zfs-l2arc, zfs-zil
```

##### SUMMARY
Reopen outputfile on SIGUSR1 so that logging is amenable to file
rotation via logrotate. This change allows you to write a simple
performance monitor daemon, which outputs a csv that's periodically
pruned by logrotate. See examples/dstat-daemon-logrotate.conf for
an example.
