### PR TITLE
Fix test suite failures in NFSv4 plugins

### DIFF
--- a/plugins/dstat_nfsd4_ops.py
+++ b/plugins/dstat_nfsd4_ops.py
@@ -57,9 +57,7 @@ class dstat_plugin(dstat):
                 'set_ssv', 'test_stateid', 'want_deleg', 'destroy_clid', 'reclaim_comp'
                 )
 
-        for line in self.splitlines():
-            fields = line.split()
-
+        for fields in self.splitlines():
             if fields[0] == "proc4ops": # just grab NFSv4 stats
                 assert int(fields[1]) == len(fields[2:]), ("reported field count (%d) does not match actual field count (%d)" % (int(fields[1]), len(fields[2:])))
                 for var in self.vars:

--- a/plugins/dstat_nfsstat4.py
+++ b/plugins/dstat_nfsstat4.py
@@ -35,9 +35,7 @@ class dstat_plugin(dstat):
                 "remove", "rename", "link", "symlink", "create", "pathconf", "statfs", "readlink",
                 "readdir", "server_caps", "delegreturn", "getacl", "setacl", "fs_locations",
                 "rel_lkowner", "secinfo")
-        for line in self.splitlines():
-
-            fields = line.split()
+        for fields in self.splitlines():
             if fields[0] == "proc4": # just grab NFSv4 stats
                 assert int(fields[1]) == len(fields[2:]), ("reported field count (%d) does not match actual field count (%d)" % (int(fields[1]), len(fields[2:])))
                 for var in self.vars:


### PR DESCRIPTION
Previously the test suite was failing with:
```
Traceback (most recent call last):
  File "./dstat", line 2846, in <module>
    main()
  File "./dstat", line 2705, in main
    scheduler.run()
  File "/usr/lib/python2.7/sched.py", line 117, in run
    action(*argument)
  File "./dstat", line 2801, in perform
    o.extract()
  File "/tmp/dstat/upstream/plugins/dstat_nfsstat4.py", line 40, in extract
    fields = line.split()
AttributeError: 'list' object has no attribute 'split'
```

This was caused by commit 56c5306554220989d7bade39924e3bf7be617990 where the NFSv4 plugin was changed to use methods from the dstat class instead of opening and splitting the file manually. Unfortunately it did not take into account that dstat.splitlines also splits the fields within a line and the NFSv4 code tried to do that again. Fix by removing the extra call to split.

Fixes: #136