### PR TITLE
add a help for --cpu-adv option.

### DIFF
--- a/dstat
+++ b/dstat
@@ -294,6 +294,7 @@ Dstat options:
   -y, --sys                enable system stats
 
   --aio                    enable aio stats
+  --cpu-adv                enable advanced cpu stats
   --fs, --filesystem       enable fs stats
   --ipc                    enable ipc stats
   --lock                   enable lock stats


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs pull-request

##### DSTAT VERSION
```
Dstat 0.7.3
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 4.4.0-43-Microsoft
Python 2.7.12 (default, Nov 19 2016, 06:48:10)
[GCC 5.4.0 20160609]

Terminal type: xterm-256color (color support)
Terminal size: 59 lines, 104 columns

Processors: 4
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio, cpu, cpu-adv, cpu-use, cpu24, disk, disk24, disk24-old, epoch, fs, int, int24, io, ipc,
        load, lock, mem, mem-adv, net, page, page24, proc, raw, socket, swap, swap-old, sys, tcp,
        time, udp, unix, vm, vm-adv, zones
/home/ozawa/workspace/dstat/plugins:
        battery, battery-remain, condor-queue, cpufreq, dbus, disk-avgqu, disk-avgrq, disk-svctm,
        disk-tps, disk-util, disk-wait, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, fuse,
        gpfs, gpfs-ops, helloworld, ib, innodb-buffer, innodb-io, innodb-ops, jvm-full, jvm-vm,
        lustre, md-status, memcache-hits, mongodb-conn, mongodb-mem, mongodb-opcount, mongodb-queue,
        mongodb-stats, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-innodb,
        mysql5-innodb-basic, mysql5-innodb-extra, mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops,
        nfsd3, nfsd3-ops, nfsd4-ops, nfsstat4, ntp, postfix, power, proc-count, qmail, redis, rpc,
        rpcd, sendmail, snmp-cpu, snmp-load, snmp-mem, snmp-net, snmp-net-err, snmp-sys, snooze,
        squid, test, thermal, top-bio, top-bio-adv, top-childwait, top-cpu, top-cpu-adv, top-cputime,
        top-cputime-avg, top-int, top-io, top-io-adv, top-latency, top-latency-avg, top-mem, top-oom,
        utmp, vm-cpu, vm-mem, vm-mem-adv, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi,
        zfs-arc, zfs-l2arc, zfs-zil
```

##### SUMMARY
dstat --cpu-adv option is useful, but not displayed when ```dstat --help```.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Before:
```
$ ./dstat --help
$ ./dstat --help
Usage: dstat [-afv] [options..] [delay [count]]
Versatile tool for generating system resource statistics

Dstat options:
  -c, --cpu                enable cpu stats
     -C 0,3,total             include cpu0, cpu3 and total
  -d, --disk               enable disk stats
     -D total,hda             include hda and total
  -g, --page               enable page stats
  -i, --int                enable interrupt stats
     -I 5,eth2                include int5 and interrupt used by eth2
  -l, --load               enable load stats
  -m, --mem                enable memory stats
  -n, --net                enable network stats
     -N eth1,total            include eth1 and total
  -p, --proc               enable process stats
  -r, --io                 enable io stats (I/O requests completed)
  -s, --swap               enable swap stats
     -S swap1,total           include swap1 and total
  -t, --time               enable time/date output
  -T, --epoch              enable time counter (seconds since epoch)
  -y, --sys                enable system stats

  --aio                    enable aio stats
  --fs, --filesystem       enable fs stats
  --ipc                    enable ipc stats
  --lock                   enable lock stats
  --raw                    enable raw stats
  --socket                 enable socket stats
  --tcp                    enable tcp stats
  --udp                    enable udp stats
  --unix                   enable unix stats
  --vm                     enable vm stats
  --vm-adv                 enable advanced vm stats
  --zones                  enable zoneinfo stats

  --list                   list all available plugins
  --<plugin-name>          enable external plugin by name (see --list)

  -a, --all                equals -cdngy (default)
  -f, --full               automatically expand -C, -D, -I, -N and -S lists
  -v, --vmstat             equals -pmgdsc -D total

  --bits                   force bits for values expressed in bytes
  --float                  force float values on screen
  --integer                force integer values on screen

  --bw, --black-on-white   change colors for white background terminal
  --color                  force colors
  --nocolor                disable colors
  --noheaders              disable repetitive headers
  --noupdate               disable intermediate updates
  --output file            write CSV output to file
  --profile                show profiling statistics when exiting dstat

delay is the delay in seconds between each update (default: 1)
count is the number of updates to display before exiting (default: unlimited)

```

After:
```
$ ./dstat --help
Usage: dstat [-afv] [options..] [delay [count]]
Versatile tool for generating system resource statistics

Dstat options:
  -c, --cpu                enable cpu stats
     -C 0,3,total             include cpu0, cpu3 and total
  -d, --disk               enable disk stats
     -D total,hda             include hda and total
  -g, --page               enable page stats
  -i, --int                enable interrupt stats
     -I 5,eth2                include int5 and interrupt used by eth2
  -l, --load               enable load stats
  -m, --mem                enable memory stats
  -n, --net                enable network stats
     -N eth1,total            include eth1 and total
  -p, --proc               enable process stats
  -r, --io                 enable io stats (I/O requests completed)
  -s, --swap               enable swap stats
     -S swap1,total           include swap1 and total
  -t, --time               enable time/date output
  -T, --epoch              enable time counter (seconds since epoch)
  -y, --sys                enable system stats

  --aio                    enable aio stats
  --cpu-adv                enable advanced cpu stats
  --fs, --filesystem       enable fs stats
  --ipc                    enable ipc stats
  --lock                   enable lock stats
  --raw                    enable raw stats
  --socket                 enable socket stats
  --tcp                    enable tcp stats
  --udp                    enable udp stats
  --unix                   enable unix stats
  --vm                     enable vm stats
  --vm-adv                 enable advanced vm stats
  --zones                  enable zoneinfo stats

  --list                   list all available plugins
  --<plugin-name>          enable external plugin by name (see --list)

  -a, --all                equals -cdngy (default)
  -f, --full               automatically expand -C, -D, -I, -N and -S lists
  -v, --vmstat             equals -pmgdsc -D total

  --bits                   force bits for values expressed in bytes
  --float                  force float values on screen
  --integer                force integer values on screen

  --bw, --black-on-white   change colors for white background terminal
  --color                  force colors
  --nocolor                disable colors
  --noheaders              disable repetitive headers
  --noupdate               disable intermediate updates
  --output file            write CSV output to file
  --profile                show profiling statistics when exiting dstat

delay is the delay in seconds between each update (default: 1)
count is the number of updates to display before exiting (default: unlimited)
```
