### PR TITLE
add --quiet which decrements debug lvl

### DIFF
--- a/dstat
+++ b/dstat
@@ -118,7 +118,8 @@ class Options:
                 ['all', 'all-plugins', 'bits', 'bw', 'black-on-white', 'color',
                  'debug', 'filesystem', 'float', 'full', 'help', 'integer',
                  'list', 'mods', 'modules', 'nocolor', 'noheaders', 'noupdate',
-                 'output=', 'pidfile=', 'profile', 'version', 'vmstat'] + allplugins)
+                 'output=', 'pidfile=', 'profile', 'quiet', 'version', 'vmstat'
+                 ] + allplugins)
         except getopt.error, exc:
             print 'dstat: %s, try dstat -h for a list of all the options' % str(exc)
             sys.exit(1)
@@ -206,6 +207,8 @@ class Options:
                 self.pidfile = arg
             elif opt in ['--profile']:
                 self.profile = 'dstat_profile.log'
+            elif opt in ['--quiet']:
+                self.debug -= 1
             elif opt in ['-h', '--help']:
                 self.usage()
                 self.help()
@@ -238,7 +241,7 @@ class Options:
             print 'dstat: delay must be an integer, greater than zero'
             sys.exit(1)
 
-        if self.debug:
+        if self.debug > 0:
             print 'Plugins: %s' % self.plugins
 
     def version(self):
@@ -1029,7 +1032,7 @@ class dstat_epoch(dstat):
         self.name = 'epoch'
         self.vars = ('epoch',)
         self.width = 10
-        if op.debug:
+        if op.debug > 0:
             self.width = 13
         self.scale = 0
 
@@ -1633,7 +1636,7 @@ class dstat_time(dstat):
         self.name = 'system'
         self.timefmt = os.getenv('DSTAT_TIMEFMT') or '%d-%m %H:%M:%S'
         self.type = 's'
-        if op.debug:
+        if op.debug > 0:
             self.width = len(time.strftime(self.timefmt, time.localtime())) + 4
         else:
             self.width = len(time.strftime(self.timefmt, time.localtime()))
@@ -1642,7 +1645,7 @@ class dstat_time(dstat):
 
     ### We are now using the starttime for this plugin, not the execution time of this plugin
     def extract(self):
-        if op.debug:
+        if op.debug > 0:
             self.val['time'] = time.strftime(self.timefmt, time.localtime(starttime)) + ".%03d" % (round(starttime * 1000 % 1000 ))
         else:
             self.val['time'] = time.strftime(self.timefmt, time.localtime(starttime))
@@ -1939,7 +1942,7 @@ def greppipe(fileobj, str, tmout = 0.001):
             return ret
         else:
             ret = ''
-    if op.debug:
+    if op.debug > 0:
         raise Exception, 'Nothing found during greppipe data collection'
     return None
 
@@ -1957,7 +1960,7 @@ def matchpipe(fileobj, string, tmout = 0.001):
             return ret
         else:
             ret = ''
-    if op.debug:
+    if op.debug > 0:
         raise Exception, 'Nothing found during matchpipe data collection'
     return None
 
@@ -2667,7 +2670,7 @@ def main():
             except Exception, e:
                 if mod == mods[-1]:
                     print >>sys.stderr, 'Module %s failed to load. (%s)' % (pluginfile, e)
-                elif op.debug:
+                elif op.debug > 0:
                     print >>sys.stderr, 'Module %s failed to load, trying another. (%s)' % (pluginfile, e)
                 if op.debug >= 3:
                     raise
@@ -2679,7 +2682,7 @@ def main():
             linewidth = linewidth + o.statwidth() + 1
             totlist.append(o)
 
-            if op.debug:
+            if op.debug > 0:
                 print 'Module', pluginfile,
                 if hasattr(o, 'file'):
                     print 'requires', o.file,
@@ -2811,7 +2814,7 @@ def perform(update):
 #            outputfile.flush()
 
         ### Print debugging output
-        if op.debug:
+        if op.debug > 0:
             totaltime = totaltime + (time.time() - starttime) * 1000.0
             if loop == 0:
                 totaltime = totaltime * step
@@ -2822,10 +2825,11 @@ def perform(update):
             elif op.debug > 2:
                 sys.stdout.write('%s%6.2f %s%d:%d:%d%s' % (theme['roundtrip'], totaltime / step, theme['debug'], loop, step, update, theme['input']))
 
-        if missed > 0:
+        if op.debug > -1: # not quiet
+            if missed > 0:
 #            sys.stdout.write(' '+theme['error']+'= warn =')
-            sys.stdout.write(' ' + theme['error'] + 'missed ' + str(missed+1) + ' ticks' + theme['input'])
-            missed = 0
+                sys.stdout.write(' ' + theme['error'] + 'missed ' + str(missed+1) + ' ticks' + theme['input'])
+                missed = 0
 
         ### Finish the line
         if not op.update:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature pull-request

##### DSTAT VERSION
```
Dstat 0.7.3
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 4.13.12-1-ARCH
Python 2.7.14 (default, Sep 20 2017, 01:25:59)
[GCC 7.2.0]

Terminal type: screen-256color (color support)
Terminal size: 70 lines, 274 columns

Processors: 4
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio, cpu, cpu-adv, cpu-use, cpu24, disk, disk24, disk24-old, epoch, fs, int, int24, io, ipc, load, lock, mem, mem-adv, net, page, page24, proc, raw, socket, swap, swap-old, sys, tcp, time, udp, unix, vm, vm-adv, zones
/home/sujeet/dev/dstat/plugins:
        battery, battery-remain, condor-queue, cpufreq, dbus, disk-avgqu, disk-avgrq, disk-svctm, disk-tps, disk-util, disk-wait, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, fuse, gpfs, gpfs-ops, helloworld, ib, innodb-buffer, innodb-io, innodb-ops, jvm-full,
        jvm-vm, lustre, md-status, memcache-hits, mongodb-conn, mongodb-mem, mongodb-opcount, mongodb-queue, mongodb-stats, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-innodb, mysql5-innodb-basic, mysql5-innodb-extra, mysql5-io, mysql5-keys, net-packets, nfs3,
        nfs3-ops, nfsd3, nfsd3-ops, nfsd4-ops, nfsstat4, ntp, postfix, power, proc-count, qmail, redis, rpc, rpcd, sendmail, snmp-cpu, snmp-load, snmp-mem, snmp-net, snmp-net-err, snmp-sys, snooze, squid, test, thermal, top-bio, top-bio-adv, top-childwait, top-cpu,
        top-cpu-adv, top-cputime, top-cputime-avg, top-int, top-io, top-io-adv, top-latency, top-latency-avg, top-mem, top-oom, utmp, vm-cpu, vm-mem, vm-mem-adv, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi, zfs-arc, zfs-l2arc, zfs-zil
/usr/share/dstat:
        battery, battery-remain, condor-queue, cpufreq, dbus, disk-avgqu, disk-avgrq, disk-svctm, disk-tps, disk-util, disk-wait, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, fuse, gpfs, gpfs-ops, helloworld, innodb-buffer, innodb-io, innodb-ops, lustre,
        md-status, memcache-hits, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-innodb, mysql5-innodb-basic, mysql5-innodb-extra, mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops, nfsd3, nfsd3-ops, nfsd4-ops, nfsstat4, ntp, postfix, power, proc-count, qmail,
        redis, rpc, rpcd, sendmail, snmp-cpu, snmp-load, snmp-mem, snmp-net, snmp-net-err, snmp-sys, snooze, squid, test, thermal, top-bio, top-bio-adv, top-childwait, top-cpu, top-cpu-adv, top-cputime, top-cputime-avg, top-int, top-io, top-io-adv, top-latency,
        top-latency-avg, top-mem, top-oom, utmp, vm-cpu, vm-mem, vm-mem-adv, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi, zfs-arc, zfs-l2arc, zfs-zil
```

##### SUMMARY
Fixes #147.

I've added a `--quiet` flag which decrements `debug` in the `Options` object. This allows `Options.debug` to become negative. All checks for `Options.debug` being zero are now checks to see that it is positive. Additionally, the missing ticks error is only reported if `Options.debug` is non-negative. Thus it is completely consistent with previous versions.

Without the `--quiet` flag:
```
python2 dstat -tdD total,nvme0n1,md0 60
----system---- -dsk/total--dsk/nvme0n1---dsk/md0--
     time     | read  writ: read  writ: read  writ
12-12 11:48:37|3867k 5977k:  32k  120k:5047k 6719k
12-12 11:48:51|2993k   15M:6729B  125k:3001k   26M^Cissed 2 ticks
```

With the `--quiet` flag:
```
python2 dstat --quiet -tdD total,nvme0n1,md0 60
----system---- -dsk/total--dsk/nvme0n1---dsk/md0--
     time     | read  writ: read  writ: read  writ
12-12 11:49:10|3867k 5977k:  32k  120k:5047k 6719k
12-12 11:49:35|3266k   17M:1966B  118k:3328k   31M^C
```
