### PR TITLE
Fix wrong NVMe-stats

### DIFF
--- a/dstat
+++ b/dstat
@@ -779,7 +779,7 @@ class dstat_disk(dstat):
     def __init__(self):
         self.nick = ('read', 'writ')
         self.type = 'b'
-        self.diskfilter = re.compile('^([hsv]d[a-z]+\d+|cciss/c\d+d\d+p\d+|dm-\d+|md\d+|mmcblk\d+p\d0|VxVM\d+)$')
+        self.diskfilter = re.compile('^([hsv]d[a-z]+\d+|cciss/c\d+d\d+p\d+|dm-\d+|md\d+|mmcblk\d+p\d0|VxVM\d+|nvme\d+n\d+p\d+)$')
         self.open('/proc/diskstats')
         self.cols = 2
 
@@ -865,7 +865,7 @@ class dstat_disk24(dstat):
     def __init__(self):
         self.nick = ('read', 'writ')
         self.type = 'b'
-        self.diskfilter = re.compile('^([hsv]d[a-z]+\d+|cciss/c\d+d\d+p\d+|dm-\d+|md\d+|mmcblk\d+p\d0|VxVM\d+)$')
+        self.diskfilter = re.compile('^([hsv]d[a-z]+\d+|cciss/c\d+d\d+p\d+|dm-\d+|md\d+|mmcblk\d+p\d0|VxVM\d+|nvme\d+n\d+p\d+)$')
         self.open('/proc/partitions')
         if self.fd and not self.discover:
             raise Exception, 'Kernel has no per-partition I/O accounting [CONFIG_BLK_STATS], use at least 2.4.20'
@@ -950,7 +950,7 @@ class dstat_disk24_old(dstat):
     def __init__(self):
         self.nick = ('read', 'writ')
         self.type = 'b'
-        self.diskfilter = re.compile('^([hsv]d[a-z]+\d+|cciss/c\d+d\d+p\d+|dm-\d+|md\d+|mmcblk\d+p\d0|VxVM\d+)$')
+        self.diskfilter = re.compile('^([hsv]d[a-z]+\d+|cciss/c\d+d\d+p\d+|dm-\d+|md\d+|mmcblk\d+p\d0|VxVM\d+|nvme\d+n\d+p\d+)$')
         self.regexp = re.compile('^\((\d+),(\d+)\):\(\d+,\d+,(\d+),\d+,(\d+)\)$')
         self.open('/proc/stat')
         self.cols = 2


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
 > ./dstat --version
Dstat 0.7.3
```

##### SUMMARY
When there was IO on an NVMe-device which has no partition, the correct stats were reported by dstat.
But for every partition it had, the stat-values were multiplied, because NVMe partitions where detected as another blockdevice.

The code already supports detecting partitions on blockdevices, just not for NVMe devices. So the fix is simple.

This is how it looks at work (left pane is fixed, right panes is current version):
https://nextcloud.th-deg.de/s/mxjMw6kfYdZcwc3

Regards