### PR TITLE
Fix top plugins when process name has spaces

### DIFF
--- a/dstat
+++ b/dstat
@@ -2010,7 +2010,23 @@ def proc_readline(filename):
 def proc_splitline(filename, sep=None):
     "Return the first line of a file splitted"
 #    return open(filename).read().split(sep)
-    return linecache.getline(filename, 1).split(sep)
+    l = linecache.getline(filename, 1).split(sep)
+
+    # If we're reading /proc/<pid>/stat, the second field (name) may include
+    # spaces. It's supposed to be wrapped in parentheses, so let's make sure
+    # we handle that.
+    if re.match("^/proc/[0-9]+/stat$", filename) and l[1].find(')') == -1:
+        i = 2
+        while i < len(l) - 1:
+            if l[i].find(')') != -1:
+                break
+            i += 1
+
+        l[1] = ' '.join(l[1:i + 1])
+        for j in range(2, i + 1):
+            l.pop(2)
+
+    return l
 
 ### FIXME: Should we cache this within every step ?
 def proc_pidlist():


### PR DESCRIPTION
According to `man proc` second field is the filename of executable:

  (2) comm  %s
  The filename of the executable, in parentheses.  This is visible whether
  or not the executable is swapped out.

This means that it can contain spaces which dstat top-* plugins are not
taking into account. This commit fixes that by implementing reading
second field until ")" is found.

##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
Dstat 0.7.2
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 3.10.0-693.el7.x86_64
Python 2.7.5 (default, Oct 30 2018, 23:45:53)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]

Terminal type: screen-256color (color support)
Terminal size: 45 lines, 191 columns

Processors: 2
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio, cpu, cpu24, disk, disk24, disk24old, epoch, fs, int, int24, io, ipc, load, lock, mem, net, page, page24, proc, raw, socket, swap, swapold, sys, tcp, time, udp, unix, vm         
/usr/share/dstat:
        battery, battery-remain, cpufreq, dbus, disk-tps, disk-util, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, gpfs, gpfs-ops, helloworld, innodb-buffer, innodb-io,           
        innodb-ops, lustre, memcache-hits, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops, nfsd3, nfsd3-ops, ntp, postfix, power,        
        proc-count, qmail, rpc, rpcd, sendmail, snooze, squid, test, thermal, top-bio, top-bio-adv, top-childwait, top-cpu, top-cpu-adv, top-cputime, top-cputime-avg, top-int, top-io,       
        top-io-adv, top-latency, top-latency-avg, top-mem, top-oom, utmp, vm-memctl, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi
```

##### SUMMARY
This fixes up top-* plugins when there's a process that has space in it's name. Basically a process name can have spaces and that's why second element of /proc/<pid>/stat has parentheses. In a result wrong values are taken into consideration when calculating usage, giving results like those (virt is multiplied by PAGE_SIZE instead of LLC):

```
[stack@devstack ~]$ dstat --top-mem
--most-expensive-
  memory process 
kuryr-daemon2665G
```
This commit fixes that by adding this as special case to proc_splitline().