### PR TITLE
Fix broken 'dstat --top-io' and 'dstat --top-io-adv' output. Used --t…

### DIFF
--- a/plugins/dstat_top_io.py
+++ b/plugins/dstat_top_io.py
@@ -26,9 +26,9 @@ class dstat_plugin(dstat):
             try:
                 ### Reset values
                 if pid not in self.pidset2:
-                    self.pidset2[pid] = {'rchar:': 0, 'wchar:': 0}
+                    self.pidset2[pid] = {'read_bytes:': 0, 'write_bytes:': 0}
                 if pid not in self.pidset1:
-                    self.pidset1[pid] = {'rchar:': 0, 'wchar:': 0}
+                    self.pidset1[pid] = {'read_bytes:': 0, 'write_bytes:': 0}
 
                 ### Extract name
                 name = proc_splitline('/proc/%s/stat' % pid)[1][1:-1]
@@ -42,8 +42,8 @@ class dstat_plugin(dstat):
             except IndexError:
                 continue
 
-            read_usage = (self.pidset2[pid]['rchar:'] - self.pidset1[pid]['rchar:']) * 1.0 / elapsed
-            write_usage = (self.pidset2[pid]['wchar:'] - self.pidset1[pid]['wchar:']) * 1.0 / elapsed
+            read_usage = (self.pidset2[pid]['read_bytes:'] - self.pidset1[pid]['read_bytes:']) * 1.0 / elapsed
+            write_usage = (self.pidset2[pid]['write_bytes:'] - self.pidset1[pid]['write_bytes:']) * 1.0 / elapsed
             usage = read_usage + write_usage
 #            if usage > 0.0:
 #                print('%s %s:%s' % (pid, read_usage, write_usage))

--- a/plugins/dstat_top_io_adv.py
+++ b/plugins/dstat_top_io_adv.py
@@ -25,9 +25,9 @@ class dstat_plugin(dstat):
             try:
                 ### Reset values
                 if pid not in self.pidset2:
-                    self.pidset2[pid] = {'rchar:': 0, 'wchar:': 0, 'cputime:': 0, 'cpuper:': 0}
+                    self.pidset2[pid] = {'read_bytes:': 0, 'write_bytes:': 0, 'cputime:': 0, 'cpuper:': 0}
                 if pid not in self.pidset1:
-                    self.pidset1[pid] = {'rchar:': 0, 'wchar:': 0, 'cputime:': 0, 'cpuper:': 0}
+                    self.pidset1[pid] = {'read_bytes:': 0, 'write_bytes:': 0, 'cputime:': 0, 'cpuper:': 0}
 
                 ### Extract name
                 name = proc_splitline('/proc/%s/stat' % pid)[1][1:-1]
@@ -52,8 +52,8 @@ class dstat_plugin(dstat):
             except IndexError:
                 continue
 
-            read_usage = (self.pidset2[pid]['rchar:'] - self.pidset1[pid]['rchar:']) * 1.0 / elapsed
-            write_usage = (self.pidset2[pid]['wchar:'] - self.pidset1[pid]['wchar:']) * 1.0 / elapsed
+            read_usage = (self.pidset2[pid]['read_bytes:'] - self.pidset1[pid]['read_bytes:']) * 1.0 / elapsed
+            write_usage = (self.pidset2[pid]['write_bytes:'] - self.pidset1[pid]['write_bytes:']) * 1.0 / elapsed
             usage = read_usage + write_usage
 
             ### Get the process that spends the most jiffies


### PR DESCRIPTION
…op-bio* to source the changes.

##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
dstat --version
Dstat 0.8.0
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 4.4.0-53-generic
Python 2.7.12 (default, Dec  4 2017, 14:50:18) 
[GCC 5.4.0 20160609]

Terminal type: xterm (color support)
Terminal size: 50 lines, 208 columns

Processors: 1
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,tcp,time,udp,
	unix,vm,vm-adv,zones
/home/vm/github/dstat4/dstat/plugins:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dstat,dstat-cpu,dstat-ctxt,dstat-mem,fan,freespace,fuse,gpfs,
	gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,
	mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,
	ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,
	top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,
	vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
dstat was inserting a newline that it should not have. I used --top-bio* as an example of how it should work. Appears to fix it. Please verify. Only tested on Linux Mint 18.3.

```
Before:
$ dstat -a --top-io-adv
----total-cpu-usage---- -dsk/total- -net/total- ---paging-- ---system-- -------most-expensive-i/o-process-------
usr sys idl wai hiq siq| read  writ| recv  send|  in   out | int   csw |process              pid  read write cpu
 10   4  86   0   0   0|  18M 3990k|   0     0 |  15k   30k|  26k   67k|
                    236183985k 107B0.0%

After:
$ dstat -a --top-io-adv
----total-cpu-usage---- -dsk/total- -net/total- ---paging-- ---system-- -------most-expensive-i/o-process-------
usr sys idl wai hiq siq| read  writ| recv  send|  in   out | int   csw |process              pid  read write cpu
 10   4  86   0   0   0|  18M 3988k|   0     0 |  15k   30k|  26k   67k|firefox              17494 108k  19k0.1%
```