### PR TITLE
Fixed bug when specifying a delay (Fixes #166)

### DIFF
--- a/dstat
+++ b/dstat
@@ -2697,7 +2697,7 @@ def perform(update):
 
         starttime = time.time()
 
-        loop = (update - 1 + op.delay) / op.delay
+        loop = (update - 1 + op.delay) // op.delay
         step = ((update - 1) % op.delay) + 1
 
         ### Get current time (may be different from schedule) for debugging


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
Dstat 0.8.0
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux
Kernel 4.19.6-300.fc29.x86_64
Python 3.7.1 (default, Oct 23 2018, 19:19:42) 
[GCC 7.3.0]

Terminal type: xterm-256color (color support)
Terminal size: 44 lines, 190 columns

Processors: 4
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,
	tcp,time,udp,unix,vm,vm-adv,zones
/home/falko/.dstat:
	freespace,rsync-count,template
/home/falko/repos/dstat/plugins:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dstat,dstat-cpu,dstat-ctxt,dstat-mem,fan,freespace,
	fuse,gpfs,gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,
	mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,
	nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,
	snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,
	top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
Fixes #166

The division in the 'loop' calculation in perform() was returning floating point values after the migration to Python 3, rather than rounding down. I changed it to floor division.

I think the floating point values kept 'loop == 0' from ever being true and the variables inside that conditional were never initialized when a delay other than 1 was specified.

Before
```
You did not select any stats, using -cdngy by default.
Traceback (most recent call last):
  File "/home/falko/repos/dstat/dstat", line 2825, in <module>
    main()
  File "/home/falko/repos/dstat/dstat", line 2684, in main
    scheduler.run()
  File "/home/falko/.conda/envs/python3/lib/python3.7/sched.py", line 151, in run
    action(*argument, **kwargs)
  File "/home/falko/repos/dstat/dstat", line 2729, in perform
    oldcols = cols
NameError: name 'cols' is not defined
```
After
```
You did not select any stats, using -cdngy by default.
--total-cpu-usage-- -dsk/total- -net/total- ---paging-- ---system--
usr sys idl wai stl| read  writ| recv  send|  in   out | int   csw 
  1   1  98   0   0|  90k  350k|   0     0 |  74B  343B| 289   275 
  0   0  99   0   0|   0    32k|  60B    0 |   0     0 | 220   193 ^C
```
