### PR TITLE
add 'ela' to self.nick

### DIFF
--- a/plugins/dstat_vm_cpu.py
+++ b/plugins/dstat_vm_cpu.py
@@ -8,7 +8,7 @@ class dstat_plugin(dstat):
     def __init__(self):
         self.name = 'vm cpu'
         self.vars = ('used', 'stolen', 'elapsed')
-        self.nick = ('usd', 'stl')
+        self.nick = ('usd', 'stl', 'ela')
         self.type = 'p'
         self.width = 3
         self.scale = 100


### PR DESCRIPTION
The "ela" is missing in the current version, so the 3rd column header in  --vm-cpu output is missing

##### ISSUE TYPE
 - Bugfix pull-request
 - Docs pull-request

##### DSTAT VERSION

I'm using the latest plugins using a custom PYTHONPATH pointing to the latest repo. This issue comes from the plugin, so the dstat main executable version should not be relevant.

```
$ dstat --version
Dstat 0.7.0
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 2.6.32-573.el6.x86_64
Python 2.6.6 (r266:84292, Jul 23 2015, 15:22:56) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

Terminal type: terminator (color support)
Terminal size: 55 lines, 130 columns

Processors: 4
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio, cpu, cpu24, disk, disk24, disk24old, epoch, fs, int, int24, io, ipc, load, lock, mem, net, page, page24, proc, raw, 
	socket, swap, swapold, sys, tcp, time, udp, unix, vm
/home/cloudera/dev/dstat/plugins:
	battery, battery-remain, condor-queue, cpufreq, dbus, disk-avgqu, disk-avgrq, disk-svctm, disk-tps, disk-util, 
	disk-wait, dstat, dstat-cpu, dstat-ctxt, dstat-mem, fan, freespace, fuse, gpfs, gpfs-ops, helloworld, ib, innodb-buffer, 
	innodb-io, innodb-ops, jvm-full, jvm-vm, lustre, md-status, memcache-hits, mongodb-conn, mongodb-mem, mongodb-opcount, 
	mongodb-queue, mongodb-stats, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-innodb, mysql5-innodb-basic, 
	mysql5-innodb-extra, mysql5-io, mysql5-keys, net-packets, nfs3, nfs3-ops, nfsd3, nfsd3-ops, nfsd4-ops, nfsstat4, ntp, 
	postfix, power, proc-count, qmail, redis, rpc, rpcd, sendmail, snmp-cpu, snmp-load, snmp-mem, snmp-net, snmp-net-err, 
	snmp-sys, snooze, squid, test, thermal, top-bio, top-bio-adv, top-childwait, top-cpu, top-cpu-adv, top-cputime, 
	top-cputime-avg, top-int, top-io, top-io-adv, top-latency, top-latency-avg, top-mem, top-oom, utmp, vm-cpu, vm-mem, 
	vm-mem-adv, vmk-hba, vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi, zfs-arc, zfs-l2arc, zfs-zil
/usr/share/dstat:
	battery, battery-remain, cpufreq, dbus, disk-util, fan, freespace, gpfs, gpfs-ops, helloworld, innodb-buffer, innodb-io, 
	innodb-ops, lustre, memcache-hits, mysql-io, mysql-keys, mysql5-cmds, mysql5-conn, mysql5-io, mysql5-keys, net-packets, 
	nfs3, nfs3-ops, nfsd3, nfsd3-ops, ntp, postfix, power, proc-count, rpc, rpcd, sendmail, snooze, thermal, top-bio, 
	top-cpu, top-cputime, top-cputime-avg, top-io, top-latency, top-latency-avg, top-mem, top-oom, utmp, vm-memctl, vmk-hba, 
	vmk-int, vmk-nic, vz-cpu, vz-io, vz-ubc, wifi
```

##### SUMMARY
Just adding a missing column header.

```
BEFORE:

[cloudera@cdh dstat]$ dstat --vm-cpu
-vm-cpu
usd stl
  2   0   0
  1   0   0

AFTER:

[cloudera@cdh plugins]$ dstat --vm-cpu
---vm-cpu--
usd stl ela
  2   0   0
  0   0   0
```