### PR TITLE
Add support for MLNX_OFED ver. 4.0+ counters directory tree

### DIFF
--- a/plugins/dstat_ib.py
+++ b/plugins/dstat_ib.py
@@ -60,10 +60,15 @@ class dstat_plugin(dstat):
             l=name.split(':');
             if len(l) < 2:
                  continue
-            rcv_counter_name=os.path.join('/sys/class/infiniband', l[0], 'ports', l[1], 'counters_ext/port_rcv_data_64')
-            xmit_counter_name=os.path.join('/sys/class/infiniband', l[0], 'ports', l[1], 'counters_ext/port_xmit_data_64')
-            rcv_lines = dopen(rcv_counter_name).readlines()
-            xmit_lines = dopen(xmit_counter_name).readlines()
+            dir_root=os.path.join('/sys/class/infiniband', l[0], 'ports', l[1]);
+            rcv_counter=glob.glob(os.path.join(dir_root, 'counter*', 'port_rcv_data*'));
+            xmit_counter=glob.glob(os.path.join(dir_root, 'counter*', 'port_xmit_data*'));
+            if not rcv_counter or not xmit_counter:
+                raise Exception('No suitable interface counter files found');
+            if len(rcv_counter) + len(xmit_counter) != 2:
+                raise Exception('No unique interface counter files found');
+            rcv_lines = dopen(rcv_counter[0]).readlines()
+            xmit_lines = dopen(xmit_counter[0]).readlines()
             if len(rcv_lines) < 1 or len(xmit_lines) < 1:
                 continue
             rcv_value = int(rcv_lines[0])
@@ -75,7 +80,7 @@ class dstat_plugin(dstat):
             for name in self.set2:
                 self.val[name] = [
                     (self.set2[name][0] - self.set1[name][0]) * 4.0 / elapsed,
-                    (self.set2[name][1] - self.set1[name][1]) * 4.0/ elapsed,
+                    (self.set2[name][1] - self.set1[name][1]) * 4.0 / elapsed,
                 ]
                 if self.val[name][0] < 0: self.val[name][0] += maxint + 1
                 if self.val[name][1] < 0: self.val[name][1] += maxint + 1


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix pull-request

##### DSTAT VERSION
```
Dstat 0.8.0
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/dstat/

Platform posix/linux2
Kernel 3.10.0-1062.12.1.el7.x86_64
Python 2.7.5 (default, Aug  7 2019, 00:51:29) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)]

Terminal type: xterm-256color (color support)
Terminal size: 54 lines, 84 columns

Processors: 60
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,
        int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,
        raw,socket,swap,swap-old,sys,tcp,time,udp,unix,vm,vm-adv,zones
/shared/home/hpcadmin/dstat/plugins:
        battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,
        disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dstat,dstat-cpu,
        dstat-ctxt,dstat-mem,fan,freespace,fuse,gpfs,gpfs-ops,helloworld,
        ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,
        md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,
        mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,
        mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,
        mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,
        nfsd4-ops,nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,
        rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,
        snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,
        top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,
        top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,
        top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,
        vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
The current implementation of the `dstat_ib` plugin is not compatible with the changes in the directory tree changes introduced with the Mellanox OFED ver. 4.0.
In the proposed fix the counter files are searched with a `glob` call and the result checked for non-null and uniqueness. In this way compatibility with the new standard is ensured without affecting backward compatibility.

Before:
```
$ ./dstat --ib -N mlx5_0:1
Traceback (most recent call last):
  File "./dstat", line 2825, in <module>
    main()
  File "./dstat", line 2684, in main
    scheduler.run()
  File "/usr/lib64/python2.7/sched.py", line 117, in run
    action(*argument)
  File "./dstat", line 2780, in perform
    o.extract()
  File "<string>", line 65, in extract
  File "./dstat", line 1863, in dopen
    raise Exception('File %s does not exist' % filename)
Exception: File /sys/class/infiniband/mlx5_0/ports/1/counters_ext/port_rcv_data_64 does not exist
```

After:
```
$ ./dstat --ib -N mlx5_0:1
-ib/mlx5_0:1-
 recv   send 
 4382k  5657M
  141k  5766M
 4345k  4893M
  178k  6530M
 4308k  4180M
```